### PR TITLE
add a mkdir for the lib folder

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,9 @@ def buildLib():
 
 def movetoLib():
     try:
+        target_lib_folder = os.path.join(root_dir, 'SpiceyPy', 'lib')
+        if not os.path.exists(target_lib_folder):
+            os.mkdir(target_lib_folder)
         os.rename(cspice_dir+'/lib/spice.so', os.path.join(root_dir,'SpiceyPy','lib','spice.so'))
 
     finally:


### PR DESCRIPTION
Your git repo does not contain a lib folder, so the move/rename fails for me. This should take care of it. One question though: What's the purpose of all those `try` commands, if you don't catch the exceptions?
