### PR TITLE
'SpicePy' was too much

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ def buildLib():
 
 def movetoLib():
     try:
-        os.rename(cspice_dir+'/lib/spice.so', os.path.join(root_dir,'SpiceyPy','lib','spice.so'))
+        os.rename(cspice_dir+'/lib/spice.so', os.path.join(root_dir, 'lib', 'spice.so'))
 
     finally:
         pass


### PR DESCRIPTION
**file** returns either relative path or absolute path to the SpiceyPy folder where the setup.py resides.
