### PR TITLE
dropping 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ matrix:
           python: 2.7
         - os: linux
           dist: trusty
-          python: 3.4
-        - os: linux
-          dist: trusty
           python: 3.5
         - os: linux
           dist: trusty
@@ -17,9 +14,6 @@ matrix:
         - os: osx
           language: generic
           env: PYVERSION='2.7.13'
-        - os: osx
-          language: generic
-          env: PYVERSION='3.4.7'
         - os: osx
           language: generic
           env: PYVERSION='3.5.4'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,15 +21,6 @@ environment:
         PLAT_NAME: "win-amd64"
         PY_TAG: "cp27"
 
-      - PYTHON: "C:\\Python34-x64"
-        CONDA: "C:\\Miniconda3-x64"
-        CONDA_BUILDS: C:\\Miniconda3-x64\conda-bld\win-64
-        PYTHON_VERSION: "3.4.x"
-        ARCH: "64"
-        WINDOWS_SDK_VERSION: "v7.1"
-        PLAT_NAME: "win-amd64"
-        PY_TAG: "cp34"
-
       - PYTHON: "C:\\Python35-x64"
         CONDA: "C:\\Miniconda35-x64"
         CONDA_BUILDS: C:\\Miniconda35-x64\conda-bld\win-64

--- a/setup.py
+++ b/setup.py
@@ -239,8 +239,6 @@ setup(
         "Topic :: Scientific/Engineering :: Astronomy",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Operating System :: MacOS :: MacOS X",


### PR DESCRIPTION
it has proved difficult to continue to support python 3.4 builds for conda on windows. This pr removes all 3.4 builds, although wheel builds continue to work for 3.4 it seems that it is just easier to drop it all and it seems that based on download statistics there are relatively few 3.4 python users now and barriers to upgrading to 3.5 or 3.6 are low. Users will still be able to install spiceypy from source (unless the metadata in setup.py actually stops it), however windows users will need to update. 