### PR TITLE
Add ProxyManager for CSPICE

### DIFF
--- a/getspice.py
+++ b/getspice.py
@@ -210,7 +210,7 @@ class GetCSPICE(object):
             try:
                 # Search proxy in ENV variables
                 proxies = {}
-                for key, value in os.environ.iteritems():
+                for key, value in os.environ.items():
                     if '_proxy' in key.lower():
                         proxies[key.lower().replace('_proxy','')] = value
 


### PR DESCRIPTION
First of all, thanks for all your efforts to provide SPICE routines to Python. Great job!

I may have missed it but it looks like the download of CSPICE fails behind proxies with `urllib3`.
It may be not the best way to do it but here is a small fix to it based on the detection of `HTTP[S]_PROXY` environment variable to enable the `ProxyManager` instead of `PoolManager`.

> Based on the docs, for [`urllib.request.urlopen`](https://docs.python.org/3/library/urllib.request.html#urllib.request.urlopen), if the proxy settings are detected (for example, when `a *_proxy` environment variable like `http_proxy` is set), ProxyHandler is default installed and makes sure the requests are handled through the proxy.