### PR TITLE
Convert standard Python datetime to ET

### DIFF
--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -11638,16 +11638,10 @@ def spkcov(spk, idcode, cover=None):
     spk = stypes.stringToCharP(spk)
     idcode = ctypes.c_int(idcode)
     if cover is None:
-<<<<<<< HEAD
-        cover=stypes.SPICEDOUBLE_CELL(2000)
-    assert isinstance(cover, stypes.SpiceCell)
-    assert cover.dtype == 1
-=======
         cover = stypes.SPICEDOUBLE_CELL(2000)
     else:
         assert isinstance(cover, stypes.SpiceCell)
         assert cover.is_double()
->>>>>>> 0321cfc16d6317a1288ae2f5cb538f478bd3d04a
     libspice.spkcov_c(spk, idcode, ctypes.byref(cover))
     return cover
 

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -13327,7 +13327,7 @@ def datetime2et(dt):
     if hasattr(dt, "__iter__"):
         ets    = []
         for t in dt:
-            libspice.utc2et_c(types.stringToCharP(t.isoformat()),ctypes.byref(lt))
+            libspice.utc2et_c(stypes.stringToCharP(t.isoformat()),ctypes.byref(lt))
             checkForSpiceError(None)
             ets.append(lt.value)
         return ets

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -13323,7 +13323,7 @@ def date2et(date):
     :return: The equivalent value in seconds past J2000, TDB.
     :rtype: float
     """
-    if isinstance(date, list):
+    if hasattr(date, "__iter__"):
         return numpy.array([utc2et(t.isoformat()) for t in date])
     date = stypes.stringToCharP(date.isoformat())
     et = ctypes.c_double()

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -13310,7 +13310,7 @@ def str2et(time):
     return et.value
 
 @spiceErrorCheck
-def datetime2et(date):
+def datetime2et(dt):
     """
     Converts a standard Python datetime to a double precision value 
     representing the number of TDB seconds past the J2000 epoch 
@@ -13323,11 +13323,16 @@ def datetime2et(date):
     :return: The equivalent value in seconds past J2000, TDB.
     :rtype: float
     """
-    if hasattr(date, "__iter__"):
-        return numpy.array([utc2et(t.isoformat()) for t in date])
-    date = stypes.stringToCharP(date.isoformat())
+    if hasattr(dt, "__iter__"):
+        ets    = []
+        for t in dt:
+            libspice.utc2et_c(ctypes.byref(t.isoformat()))
+            checkForSpiceError(None)
+            ets.append(lt.value)
+        return ets
+    dt = stypes.stringToCharP(dt.isoformat())
     et = ctypes.c_double()
-    libspice.utc2et_c(date, ctypes.byref(et))
+    libspice.utc2et_c(dt, ctypes.byref(et))
     return et.value
 
 @spiceErrorCheck

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -11572,7 +11572,7 @@ def spkcov(spk, idcode, cover=None):
     spk = stypes.stringToCharP(spk)
     idcode = ctypes.c_int(idcode)
     if cover is None:
-        cover=stypes.SPICEDOUBLE_CELL(2)
+        cover=stypes.SPICEDOUBLE_CELL(2000)
     assert isinstance(cover, stypes.SpiceCell)
     assert cover.dtype == 1
     libspice.spkcov_c(spk, idcode, ctypes.byref(cover))

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -13310,7 +13310,7 @@ def str2et(time):
     return et.value
 
 @spiceErrorCheck
-def date2et(date):
+def datetime2et(date):
     """
     Converts a standard Python datetime to a double precision value 
     representing the number of TDB seconds past the J2000 epoch 

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -11571,7 +11571,7 @@ def spkcov(spk, idcode, cover=None):
     """
     spk = stypes.stringToCharP(spk)
     idcode = ctypes.c_int(idcode)
-    if not cover:
+    if cover is None:
         cover=stypes.SPICEDOUBLE_CELL(2)
     assert isinstance(cover, stypes.SpiceCell)
     assert cover.dtype == 1

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -13310,7 +13310,7 @@ def str2et(time):
     return et.value
 
 @spiceErrorCheck
-def date2et(datetime):
+def date2et(date):
     """
     Converts a standard Python datetime to a double precision value 
 	representing the number of TDB seconds past the J2000 epoch 
@@ -13323,11 +13323,11 @@ def date2et(datetime):
     :return: The equivalent value in seconds past J2000, TDB.
     :rtype: float
     """
-    if isinstance(datetime, list):
-        return numpy.array([utc2et(t.isoformat()) for t in datetime])
-    datetime = stypes.stringToCharP(datetime.isoformat())
+    if isinstance(date, list):
+        return numpy.array([utc2et(t.isoformat()) for t in date])
+    date = stypes.stringToCharP(date.isoformat())
     et = ctypes.c_double()
-    libspice.utc2et_c(datetime, ctypes.byref(et))
+    libspice.utc2et_c(date, ctypes.byref(et))
     return et.value
 
 @spiceErrorCheck

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -13313,7 +13313,7 @@ def str2et(time):
 def date2et(date):
     """
     Converts a standard Python datetime to a double precision value 
-	representing the number of TDB seconds past the J2000 epoch 
+    representing the number of TDB seconds past the J2000 epoch 
 	corresponding to the input epoch.
 
     https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/FORTRAN/req/time.html#The%20J2000%20Epoch

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -13242,6 +13242,26 @@ def str2et(time):
     libspice.str2et_c(time, ctypes.byref(et))
     return et.value
 
+@spiceErrorCheck
+def date2et(datetime):
+    """
+    Converts a standard Python datetime to a double precision value 
+	representing the number of TDB seconds past the J2000 epoch 
+	corresponding to the input epoch.
+
+    https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/FORTRAN/req/time.html#The%20J2000%20Epoch
+
+    :param date: A standard Python datetime
+    :type time: datetime
+    :return: The equivalent value in seconds past J2000, TDB.
+    :rtype: float
+    """
+    if isinstance(datetime, list):
+        return numpy.array([utc2et(t.isoformat()) for t in datetime])
+    datetime = stypes.stringToCharP(datetime.isoformat())
+    et = ctypes.c_double()
+    libspice.utc2et_c(datetime, ctypes.byref(et))
+    return et.value
 
 @spiceErrorCheck
 def subpnt(method, target, et, fixref, abcorr, obsrvr):

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -13318,15 +13318,16 @@ def datetime2et(dt):
 
     https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/FORTRAN/req/time.html#The%20J2000%20Epoch
 
-    :param date: A standard Python datetime
+    :param dt: A standard Python datetime
     :type time: datetime
     :return: The equivalent value in seconds past J2000, TDB.
     :rtype: float
     """
+    lt = ctypes.c_double()
     if hasattr(dt, "__iter__"):
         ets    = []
         for t in dt:
-            libspice.utc2et_c(ctypes.byref(t.isoformat()))
+            libspice.utc2et_c(t.isoformat(),ctypes.byref(lt))
             checkForSpiceError(None)
             ets.append(lt.value)
         return ets

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -13327,7 +13327,7 @@ def datetime2et(dt):
     if hasattr(dt, "__iter__"):
         ets    = []
         for t in dt:
-            libspice.utc2et_c(t.isoformat(),ctypes.byref(lt))
+            libspice.utc2et_c(types.stringToCharP(t.isoformat()),ctypes.byref(lt))
             checkForSpiceError(None)
             ets.append(lt.value)
         return ets

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -11555,7 +11555,7 @@ def spkcls(handle):
 
 
 @spiceErrorCheck
-def spkcov(spk, idcode, cover):
+def spkcov(spk, idcode, cover=None):
     """
     Find the coverage window for a specified ephemeris object in a
     specified SPK file.
@@ -11571,9 +11571,12 @@ def spkcov(spk, idcode, cover):
     """
     spk = stypes.stringToCharP(spk)
     idcode = ctypes.c_int(idcode)
+    if not cover:
+        cover=stypes.SPICEDOUBLE_CELL(2)
     assert isinstance(cover, stypes.SpiceCell)
     assert cover.dtype == 1
     libspice.spkcov_c(spk, idcode, ctypes.byref(cover))
+    return cover
 
 
 @spiceErrorCheck

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -13314,7 +13314,7 @@ def date2et(date):
     """
     Converts a standard Python datetime to a double precision value 
     representing the number of TDB seconds past the J2000 epoch 
-	corresponding to the input epoch.
+    corresponding to the input epoch.
 
     https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/FORTRAN/req/time.html#The%20J2000%20Epoch
 

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -30,6 +30,7 @@ from .utils.callbacks import SpiceUDFUNS, SpiceUDFUNB
 import functools
 import numpy
 from contextlib import contextmanager
+from datetime import datetime
 
 
 __author__ = 'AndrewAnnex'

--- a/spiceypy/tests/test_wrapper.py
+++ b/spiceypy/tests/test_wrapper.py
@@ -6119,14 +6119,16 @@ def test_spkcov():
     ids = spice.spkobj(CoreKernels.spk)
     tempObj = ids[0]
     
+    #Checks for defaults
     cover=spice.spkcov(CoreKernels.spk, tempObj)
     result = [x for x in cover]
     expected = [-94651137.81606464, 315662463.18395346]
     npt.assert_array_almost_equal(result, expected)
     
+    #Checks for old way, where if cover is pre-set, it should remain set
     cover = spice.stypes.SPICEDOUBLE_CELL(2000)
     spice.scard(0, cover)
-    cover=spice.spkcov(CoreKernels.spk, tempObj, cover)
+    spice.spkcov(CoreKernels.spk, tempObj, cover)
     result = [x for x in cover]
     expected = [-94651137.81606464, 315662463.18395346]
     npt.assert_array_almost_equal(result, expected)

--- a/spiceypy/tests/test_wrapper.py
+++ b/spiceypy/tests/test_wrapper.py
@@ -27,6 +27,7 @@ import spiceypy as spice
 import numpy as np
 import numpy.testing as npt
 import os
+from datetime import datetime
 
 import spiceypy.utils.callbacks
 from spiceypy.tests.gettestkernels import downloadKernels,\
@@ -7139,6 +7140,23 @@ def test_str2et():
     date = 'Thu Mar 20 12:53:29 PST 1997'
     et = spice.str2et(date)
     npt.assert_almost_equal(et, -87836728.81438904)
+    spice.kclear()
+    
+def test_date2et():
+    spice.kclear()
+    spice.furnsh(CoreKernels.testMetaKernel)
+    date = datetime(1997,3,20,12,53,29)
+    et = spice.str2et(date)
+    npt.assert_almost_equal(et, -87836728.81438904)
+    
+    expecteds=[-87836728.81438904,-792086354.8170365,-790847954.8166842]
+    dates = [datetime(1997,3,20,12,53,29),
+             datetime(1974,11,25,20,0,0),
+             datetime(1974,12,10,04,0,0),
+             
+    results = spice.str2et(dates)
+    for expected, result in zip(expecteds, results)
+        npt.assert_almost_equal(result, expected)
     spice.kclear()
 
 

--- a/spiceypy/tests/test_wrapper.py
+++ b/spiceypy/tests/test_wrapper.py
@@ -6119,7 +6119,12 @@ def test_spkcov():
     ids = spice.spkobj(CoreKernels.spk)
     tempObj = ids[0]
     spice.scard(0, cover)
-    spice.spkcov(CoreKernels.spk, tempObj, cover)
+    cover=spice.spkcov(CoreKernels.spk, tempObj, cover)
+    result = [x for x in cover]
+    expected = [-94651137.81606464, 315662463.18395346]
+    npt.assert_array_almost_equal(result, expected)
+    
+    cover=spice.spkcov(CoreKernels.spk, tempObj)
     result = [x for x in cover]
     expected = [-94651137.81606464, 315662463.18395346]
     npt.assert_array_almost_equal(result, expected)

--- a/spiceypy/tests/test_wrapper.py
+++ b/spiceypy/tests/test_wrapper.py
@@ -7147,9 +7147,9 @@ def test_date2et():
     spice.furnsh(CoreKernels.testMetaKernel)
     date = datetime(1997,3,20,12,53,29)
     et = spice.date2et(date)
-    npt.assert_almost_equal(et, -87836728.81438904)
+    npt.assert_almost_equal(et, -87865528.8143913)
     
-    expecteds=[-87836728.81438904,-792086354.8170365,-790847954.8166842]
+    expecteds=[-87865528.8143913,-792086354.8170365,-790847954.8166842]
     dates = [datetime(1997,3,20,12,53,29),
              datetime(1974,11,25,20,0,0),
              datetime(1974,12,10,4,0,0)]

--- a/spiceypy/tests/test_wrapper.py
+++ b/spiceypy/tests/test_wrapper.py
@@ -7152,7 +7152,7 @@ def test_date2et():
     expecteds=[-87836728.81438904,-792086354.8170365,-790847954.8166842]
     dates = [datetime(1997,3,20,12,53,29),
              datetime(1974,11,25,20,0,0),
-             datetime(1974,12,10,04,0,0)]
+             datetime(1974,12,10,4,0,0)]
              
     results = spice.str2et(dates)
     for expected, result in zip(expecteds, results):

--- a/spiceypy/tests/test_wrapper.py
+++ b/spiceypy/tests/test_wrapper.py
@@ -7146,7 +7146,7 @@ def test_date2et():
     spice.kclear()
     spice.furnsh(CoreKernels.testMetaKernel)
     date = datetime(1997,3,20,12,53,29)
-    et = spice.str2et(date)
+    et = spice.date2et(date)
     npt.assert_almost_equal(et, -87836728.81438904)
     
     expecteds=[-87836728.81438904,-792086354.8170365,-790847954.8166842]
@@ -7154,7 +7154,7 @@ def test_date2et():
              datetime(1974,11,25,20,0,0),
              datetime(1974,12,10,4,0,0)]
              
-    results = spice.str2et(dates)
+    results = spice.date2et(dates)
     for expected, result in zip(expecteds, results):
         npt.assert_almost_equal(result, expected)
     spice.kclear()

--- a/spiceypy/tests/test_wrapper.py
+++ b/spiceypy/tests/test_wrapper.py
@@ -7155,7 +7155,7 @@ def test_date2et():
              datetime(1974,12,10,04,0,0)]
              
     results = spice.str2et(dates)
-    for expected, result in zip(expecteds, results)
+    for expected, result in zip(expecteds, results):
         npt.assert_almost_equal(result, expected)
     spice.kclear()
 

--- a/spiceypy/tests/test_wrapper.py
+++ b/spiceypy/tests/test_wrapper.py
@@ -6115,19 +6115,22 @@ def test_spkcls():
 
 def test_spkcov():
     spice.kclear()
-    cover = spice.stypes.SPICEDOUBLE_CELL(2000)
+    
     ids = spice.spkobj(CoreKernels.spk)
     tempObj = ids[0]
+    
+    cover=spice.spkcov(CoreKernels.spk, tempObj)
+    result = [x for x in cover]
+    expected = [-94651137.81606464, 315662463.18395346]
+    npt.assert_array_almost_equal(result, expected)
+    
+    cover = spice.stypes.SPICEDOUBLE_CELL(2000)
     spice.scard(0, cover)
     cover=spice.spkcov(CoreKernels.spk, tempObj, cover)
     result = [x for x in cover]
     expected = [-94651137.81606464, 315662463.18395346]
     npt.assert_array_almost_equal(result, expected)
     
-    cover=spice.spkcov(CoreKernels.spk, tempObj)
-    result = [x for x in cover]
-    expected = [-94651137.81606464, 315662463.18395346]
-    npt.assert_array_almost_equal(result, expected)
     spice.kclear()
 
 

--- a/spiceypy/tests/test_wrapper.py
+++ b/spiceypy/tests/test_wrapper.py
@@ -7152,7 +7152,7 @@ def test_date2et():
     expecteds=[-87836728.81438904,-792086354.8170365,-790847954.8166842]
     dates = [datetime(1997,3,20,12,53,29),
              datetime(1974,11,25,20,0,0),
-             datetime(1974,12,10,04,0,0),
+             datetime(1974,12,10,04,0,0)]
              
     results = spice.str2et(dates)
     for expected, result in zip(expecteds, results)

--- a/spiceypy/tests/test_wrapper.py
+++ b/spiceypy/tests/test_wrapper.py
@@ -7142,11 +7142,11 @@ def test_str2et():
     npt.assert_almost_equal(et, -87836728.81438904)
     spice.kclear()
     
-def test_date2et():
+def test_datetime2et():
     spice.kclear()
     spice.furnsh(CoreKernels.testMetaKernel)
     date = datetime(1997,3,20,12,53,29)
-    et = spice.date2et(date)
+    et = spice.datetime2et(date)
     npt.assert_almost_equal(et, -87865528.8143913)
     
     expecteds=[-87865528.8143913,-792086354.8170365,-790847954.8166842]
@@ -7154,7 +7154,7 @@ def test_date2et():
              datetime(1974,11,25,20,0,0),
              datetime(1974,12,10,4,0,0)]
              
-    results = spice.date2et(dates)
+    results = spice.datetime2et(dates)
     for expected, result in zip(expecteds, results):
         npt.assert_almost_equal(result, expected)
     spice.kclear()


### PR DESCRIPTION
Adding functionality to convert Python's datetime to an et directly, bypassing the need to convert to a string in program should datetimes be utilized.