### PR TITLE
Wrap tkfram, ckfrot, and zzdynrot

### DIFF
--- a/appveyor/cspice.def
+++ b/appveyor/cspice.def
@@ -32,6 +32,7 @@ EXPORTS			appndc_c
 				cidfrm_c
 				ckcls_c
 				ckcov_c
+				ckfrot_
 				ckgp_c
 				ckgpav_c
 				cklpf_c
@@ -503,6 +504,7 @@ EXPORTS			appndc_c
 				timout_c
 				tipbod_c
 				tisbod_c
+				tkfram_
 				tkvrsn_c
 				tparse_c
 				tpictr_c
@@ -590,3 +592,4 @@ EXPORTS			appndc_c
 				xposeg_c
 				zzgetcml_c
 				zzgfsavh_c
+				zzdynrot_

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -1015,7 +1015,7 @@ def ckfrot(inst, et):
     ref = ctypes.c_int()
     found = ctypes.c_int()
     libspice.ckfrot_(ctypes.byref(inst), ctypes.byref(et), rotate, ctypes.byref(ref), ctypes.byref(found))
-    return stypes.cMatrixToNumpy(rotate), ref.value, bool(found)
+    return stypes.cMatrixToNumpy(rotate), ref.value, bool(found.value)
 
 
 @spiceErrorCheck
@@ -13986,7 +13986,7 @@ def tkfram(typid):
     found = ctypes.c_int()
     libspice.tkfram_(ctypes.byref(code), matrix, ctypes.byref(nextFrame), ctypes.byref(found))
 
-    return stypes.cMatrixToNumpy(matrix), nextFrame.value, bool(found)
+    return stypes.cMatrixToNumpy(matrix), nextFrame.value, bool(found.value)
 
 # @spiceErrorCheck
 def tkvrsn(item):

--- a/spiceypy/tests/gettestkernels.py
+++ b/spiceypy/tests/gettestkernels.py
@@ -73,12 +73,14 @@ class ExtraKernels(object):
     earthHighPerPck_url = "https://raw.githubusercontent.com/AndrewAnnex/SpiceyPyTestKernels/master/earth_031228_231229_predict.bpc"
     phobosDsk_url       = "https://raw.githubusercontent.com/AndrewAnnex/SpiceyPyTestKernels/master/phobos_lores.bds"
     marsSpk_url         = "https://raw.githubusercontent.com/AndrewAnnex/SpiceyPyTestKernels/master/mar022-1.bsp"
+    mroFk_url           = "https://naif.jpl.nasa.gov/pub/naif/MRO/kernels/fk/mro_v15.tf"
     voyagerSclk         = getPathFromUrl(voyagerSclk_url)
     earthTopoTf         = getPathFromUrl(earthTopoTf_url)
     earthStnSpk         = getPathFromUrl(earthStnSpk_url)
     earthHighPerPck     = getPathFromUrl(earthHighPerPck_url)
     phobosDsk           = getPathFromUrl(phobosDsk_url)
     marsSpk             = getPathFromUrl(marsSpk_url)
+    mroFk               = getPathFromUrl(mroFk_url)
 
 def cleanup_Extra_Kernels():
     cleanupFile(ExtraKernels.voyagerSclk)
@@ -87,6 +89,7 @@ def cleanup_Extra_Kernels():
     cleanupFile(ExtraKernels.earthHighPerPck)
     cleanupFile(ExtraKernels.phobosDsk)
     cleanupFile(ExtraKernels.marsSpk)
+    cleanupFile(ExtraKernels.mroFk)
 
 
 class CoreKernels(object):
@@ -159,6 +162,7 @@ def getExtraTestKernels():
     getKernel(ExtraKernels.earthHighPerPck_url)
     getKernel(ExtraKernels.phobosDsk_url)
     getKernel(ExtraKernels.marsSpk_url)
+    getKernel(ExtraKernels.mroFk_url)
 
 
 def getCassiniTestKernels():

--- a/spiceypy/tests/gettestkernels.py
+++ b/spiceypy/tests/gettestkernels.py
@@ -73,7 +73,7 @@ class ExtraKernels(object):
     earthHighPerPck_url = "https://raw.githubusercontent.com/AndrewAnnex/SpiceyPyTestKernels/master/earth_031228_231229_predict.bpc"
     phobosDsk_url       = "https://raw.githubusercontent.com/AndrewAnnex/SpiceyPyTestKernels/master/phobos_lores.bds"
     marsSpk_url         = "https://raw.githubusercontent.com/AndrewAnnex/SpiceyPyTestKernels/master/mar022-1.bsp"
-    mroFk_url           = "https://naif.jpl.nasa.gov/pub/naif/MRO/kernels/fk/mro_v15.tf"
+    mroFk_url           = "https://raw.githubusercontent.com/AndrewAnnex/SpiceyPyTestKernels/master/mro_v15.tf"
     voyagerSclk         = getPathFromUrl(voyagerSclk_url)
     earthTopoTf         = getPathFromUrl(earthTopoTf_url)
     earthStnSpk         = getPathFromUrl(earthStnSpk_url)

--- a/spiceypy/tests/test_wrapper.py
+++ b/spiceypy/tests/test_wrapper.py
@@ -376,6 +376,24 @@ def test_ckcov():
     assert [[cover[i*2],cover[i*2+1]] for i in range(spice.wncard(cover))] == expected_intervals
     spice.kclear()
 
+def test_ckfrot():
+    spice.kclear()
+    spice.furnsh(CoreKernels.testMetaKernel)
+    spice.furnsh(CassiniKernels.cassSclk)
+    spice.furnsh(CassiniKernels.cassCk)
+    spice.furnsh(CassiniKernels.cassIk)
+    spice.furnsh(CassiniKernels.cassFk)
+    spice.furnsh(CassiniKernels.cassPck)
+    ckid = spice.ckobj(CassiniKernels.cassCk)[0]
+    # aribtrary time covered by test ck kernel 
+    et = spice.str2et("2013-FEB-26 00:01:08.828")
+    rotation, ref = spice.ckfrot(ckid, et)
+    expected = np.array([[-0.64399206,  0.48057295,  0.5952511 ],
+                         [-0.34110294, -0.87682328,  0.33886533],
+                         [ 0.68477954,  0.01518468,  0.72859208]])
+    npt.assert_array_almost_equal(rotation, expected)
+    assert ref == 1 
+    spice.kclear()
 
 def test_ckgp():
     spice.kclear()
@@ -7447,6 +7465,19 @@ def test_tisbod():
     spice.kclear()
 
 
+def test_tkfram():
+    spice.kclear()
+    spice.furnsh(CoreKernels.testMetaKernel)
+    spice.furnsh(CassiniKernels.cassFk)
+    rotation, nextFrame = spice.tkfram(-82001)
+    expected = np.array([[6.12323400e-17, 0.00000000e+00, -1.00000000e+00],
+                         [0.00000000e+00, 1.00000000e+00, -0.00000000e+00],
+                         [1.00000000e+00, 0.00000000e+00, 6.12323400e-17]])
+    npt.assert_array_almost_equal(rotation, expected)
+    assert nextFrame == -82000                                               
+    spice.kclear()
+
+
 def test_tkvrsn():
     version = spice.tkvrsn("toolkit")
     assert version == "CSPICE_N0066"
@@ -8274,6 +8305,16 @@ def test_xposeg():
     npt.assert_array_almost_equal(spice.xposeg(m1, 3, 3), [[1.0, 0.0, 0.0], [2.0, 4.0, 6.0], [3.0, 5.0, 0.0]])
     npt.assert_array_almost_equal(spice.xposeg(np.array(m1), 3, 3), [[1.0, 0.0, 0.0], [2.0, 4.0, 6.0], [3.0, 5.0, 0.0]])
 
+def test_zzdynrot():
+    spice.kclear()
+    spice.furnsh(ExtraKernels.mroFk)
+    rotation, frame = spice.zzdynrot(-74900, 499, 221051477.42023)
+    expected = np.array([[ 0.6733481,   0.73932559,  0.0       ],
+                         [-0.5895359,   0.53692566,  0.60345527],
+                         [ 0.44614992, -0.40633546,  0.79739685]])
+    npt.assert_array_almost_equal(rotation, expected)
+    assert frame == 1                                            
+    spice.kclear()
 
 def teardown_tests():
     # Tests that must be done last are put here and

--- a/spiceypy/utils/libspicehelper.py
+++ b/spiceypy/utils/libspicehelper.py
@@ -97,6 +97,7 @@ libspice.cidfrm_c.argtypes = [c_int, c_int, c_int_p, c_char_p, c_int_p]
 libspice.ckcls_c.argtypes = [c_int]
 libspice.ckcov_c.argtypes = [c_char_p, c_int, c_int, c_char_p, c_double, c_char_p, s_cell_p]
 libspice.ckobj_c.argtypes = [c_char_p, s_cell_p]
+libspice.ckfrot_.argtypes = [c_int_p, c_double_p, (c_double * 3) * 3, c_int_p, c_int_p]
 libspice.ckgp_c.argtypes = [c_int, c_double, c_double, c_char_p, ((c_double * 3) * 3), c_double_p,
                             c_int_p]
 libspice.ckgpav_c.argtypes = [c_int, c_double, c_double, c_char_p, ((c_double * 3) * 3), (c_double * 3),
@@ -762,6 +763,7 @@ libspice.timdef_c.argtypes = [c_char_p, c_char_p, c_int, c_char_p]
 libspice.timout_c.argtypes = [c_double, c_char_p, c_int, c_char_p]
 libspice.tipbod_c.argtypes = [c_char_p, c_int, c_double, (c_double * 3) * 3]
 libspice.tisbod_c.argtypes = [c_char_p, c_int, c_double, (c_double * 6) * 6]
+libspice.tkfram_.argtypes = [c_int_p, (c_double * 3) * 3, c_int_p, c_int_p]
 libspice.tkvrsn_c.argtypes = [c_char_p]
 libspice.tkvrsn_c.restype  = c_char_p
 libspice.tparse_c.argtypes = [c_char_p, c_int, c_double_p, c_char_p]
@@ -889,7 +891,8 @@ libspice.xpose6_c.argtypes = [(c_double * 6) * 6, (c_double * 6) * 6]
 libspice.xposeg_c.argtypes = [c_void_p, c_int, c_int, c_void_p]
 ########################################################################################################################
 # Z
-
+libspice.zzdynrot_.argtypes = [c_int_p, c_int_p, c_double_p, (c_double * 3) * 3, c_int_p]
 libspice.zzgetcml_c.argtypes = [c_int, c_char_p, c_int]
 libspice.zzgfsavh_c.argtypes = [c_int]
+
 #libspice.zzsynccl_c.argtypes = [None]


### PR DESCRIPTION
This PR wraps `tkram`, `ckfrot`, and `zzdynrot` which are available in the spice library, but not available via the c interface. 

The links in the docstrings for `tkfram` and `ckfrot` point to naif's FORTRAN library documentation for more information, and there is no link for `zzdynrot` as I was unable to locate public documentation.

I needed to add new test data to test `zzdynrot`, as the existing test data didn't seem to include a dynamic frame to use for testing. 