### PR TITLE
adding tests to the install 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
-from setuptools import setup, Command
+from setuptools import setup, find_packages, Command
 from setuptools.command.install import install
 from setuptools.command.build_py import build_py
 from setuptools.command.test import test as TestCommand
@@ -318,7 +318,7 @@ setup(
         "Operating System :: POSIX :: BSD :: FreeBSD",
         "Operating System :: Microsoft :: Windows"
     ],
-    packages=['spiceypy', 'spiceypy.utils'],
+    packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
     distclass=SpiceyPyBinaryDistribution,


### PR DESCRIPTION
so that pytest can take advantage of them more easily in some CI environments

should help fix an issue in pr https://github.com/conda-forge/spiceypy-feedstock/pull/16