### PR TITLE
vectorize 3 functions. add tests.

### DIFF
--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -5060,7 +5060,7 @@ def et2utc(et, formatStr, prec, lenout=_default_len_out):
     http://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/et2utc_c.html
 
     :param et: Input epoch, given in ephemeris seconds past J2000.
-    :type et: float
+    :type et: Union[float,Iterable[float]]
     :param formatStr: Format of output epoch.
     :type formatStr: str
     :param prec: Digits of precision in fractional seconds or days.
@@ -5068,15 +5068,22 @@ def et2utc(et, formatStr, prec, lenout=_default_len_out):
     :param lenout: The length of the output string plus 1.
     :type lenout: int
     :return: Output time string in UTC
-    :rtype: str
+    :rtype: Union[str,Iterable[str]]
     """
-    et = ctypes.c_double(et)
     prec = ctypes.c_int(prec)
     lenout = ctypes.c_int(lenout)
     formatStr = stypes.stringToCharP(formatStr)
     utcstr = stypes.stringToCharP(lenout)
-    libspice.et2utc_c(et, formatStr, prec, lenout, utcstr)
-    return stypes.toPythonString(utcstr)
+    if stypes.isiterable(et):
+        results = []
+        for t in et:
+            libspice.et2utc_c(ctypes.c_double(t), formatStr, prec, lenout, utcstr)
+            checkForSpiceError(None)
+            results.append(stypes.toPythonString(utcstr))
+        return results
+    else:
+        libspice.et2utc_c(ctypes.c_double(et), formatStr, prec, lenout, utcstr)
+        return stypes.toPythonString(utcstr)
 
 
 @spiceErrorCheck
@@ -11002,17 +11009,24 @@ def scencd(sc, sclkch, MXPART=None):
     :param sc: NAIF spacecraft identification code.
     :type sc: int
     :param sclkch: Character representation of a spacecraft clock.
-    :type sclkch: str
+    :type sclkch: Union[str,Iterable[str]]
     :param MXPART: Maximum number of spacecraft clock partitions.
     :type MXPART: int
     :return: Encoded representation of the clock count.
-    :rtype: float
+    :rtype: Union[float,Iterable[float]]
     """
     sc = ctypes.c_int(sc)
-    sclkch = stypes.stringToCharP(sclkch)
     sclkdp = ctypes.c_double()
-    libspice.scencd_c(sc, sclkch, ctypes.byref(sclkdp))
-    return sclkdp.value
+    if stypes.isiterable(sclkch):
+        results = []
+        for chars in sclkch:
+            libspice.scencd_c(sc, stypes.stringToCharP(chars), ctypes.byref(sclkdp))
+            checkForSpiceError(None)
+            results.append(sclkdp.value)
+        return results
+    else:
+        libspice.scencd_c(sc, stypes.stringToCharP(sclkch), ctypes.byref(sclkdp))
+        return sclkdp.value
 
 
 @spiceErrorCheck
@@ -11096,15 +11110,23 @@ def sct2e(sc, sclkdp):
     :param sc: NAIF spacecraft ID code.
     :type sc: int
     :param sclkdp: SCLK, encoded as ticks since spacecraft clock start.
-    :type sclkdp: float
+    :type sclkdp: Union[float,Iterable[float]]
     :return: Ephemeris time, seconds past J2000.
-    :rtype: float
+    :rtype: Union[float,Iterable[float]]
     """
     sc = ctypes.c_int(sc)
-    sclkdp = ctypes.c_double(sclkdp)
     et = ctypes.c_double()
-    libspice.sct2e_c(sc, sclkdp, ctypes.byref(et))
-    return et.value
+    if stypes.isiterable(sclkdp):
+        results = []
+        for sclk in sclkdp:
+            libspice.sct2e_c(sc, ctypes.c_double(sclk), ctypes.byref(et))        
+            checkForSpiceError(None)
+            results.append(et.value)
+        return results
+    else:
+        sclkdp = ctypes.c_double(sclkdp)
+        libspice.sct2e_c(sc, sclkdp, ctypes.byref(et))
+        return et.value
 
 
 @spiceErrorCheck

--- a/spiceypy/tests/test_wrapper.py
+++ b/spiceypy/tests/test_wrapper.py
@@ -2953,6 +2953,15 @@ def test_et2utc():
     spice.kclear()
 
 
+def test_et2utc_vectorized():
+    spice.kclear()
+    spice.furnsh(CoreKernels.testMetaKernel)
+    et = -527644192.5403653
+    output = spice.et2utc(3 * [et], "J", 6)
+    assert output == 3 * ["JD 2445438.006415"]
+    spice.kclear()
+        
+
 def test_etcal():
     et = np.arange(0, 20)
     cal = spice.etcal(et[0])
@@ -5801,6 +5810,16 @@ def test_scencd():
     spice.kclear()
 
 
+def test_scencd_vectorized():
+    spice.kclear()
+    spice.furnsh(CoreKernels.testMetaKernel)
+    spice.furnsh(ExtraKernels.voyagerSclk)
+    sclkch = '2/20538:39:768'
+    sclkdp = spice.scencd(-32, 3 * [sclkch])
+    npt.assert_almost_equal(sclkdp, 3*[985327950.0], decimal=6)
+    spice.kclear()
+    
+    
 def test_scfmt():
     spice.kclear()
     spice.furnsh(CoreKernels.testMetaKernel)
@@ -5844,6 +5863,18 @@ def test_sct2e():
     spice.kclear()
 
 
+def test_sct2e_vectorized():
+    spice.kclear()
+    spice.furnsh(CoreKernels.testMetaKernel)
+    spice.furnsh(ExtraKernels.voyagerSclk)
+    inputlist = 3 * [985327965.0]
+    # -32 is the SPICE code for Voyager 2
+    to_test = spice.sct2e(-32, inputlist)
+    expected = -646668527.6822292
+    npt.assert_almost_equal(3 * [expected], to_test, decimal=6)
+    spice.kclear()
+    
+    
 def test_sctiks():
     spice.kclear()
     spice.furnsh(CoreKernels.testMetaKernel)


### PR DESCRIPTION
fixes #310 

I totally agree about keeping fixes to the exact issue, so I kept it to the 3 functions addressed by the issue, sorry for the mess. (Interestingly, merging in your new stuff from master should have worked cleanly (and was required anyway for your new stypes function), as that is accepted practice for keeping a fix branch up-to-date for review, so I'm not sure what went wrong there, I did do a rebase.

I totally disagree that a PR creator should have to adapt to your non-standard way of working.
Reduction of efforts for PRs is a double-side sword, both on the reviewer and the creator and if all sides follow accepted standards, all sides' effort is lower.
It's obviously your prerogative to stay off of PEP8, but you shouldn't be surprised if you don't get any PRs then, because people are forced to change their development environments  to create code that ignores standards.
These days a dev env should be properly set-up with code style and quality linters and editors that remove trailing whitespace, so I made an exception for this today and forced my editor to ignore stuff that is ignoring standards, but I unfortunately won't be able to submit PRs anymore with this situation. I would be happy in collaborating in getting SpiceyPy to follow accepted standards though, just let me know.
