### PR TITLE
Fixing SyntaxWarning in python 3.8

### DIFF
--- a/spiceypy/__init__.py
+++ b/spiceypy/__init__.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) [2015-2019] [Andrew Annex]
+Copyright (c) [2015-2020] [Andrew Annex]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/spiceypy/config.py
+++ b/spiceypy/config.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) [2015-2019] [Andrew Annex]
+Copyright (c) [2015-2020] [Andrew Annex]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) [2015-2019] [Andrew Annex]
+Copyright (c) [2015-2020] [Andrew Annex]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/spiceypy/tests/__init__.py
+++ b/spiceypy/tests/__init__.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) [2015-2019] [Andrew Annex]
+Copyright (c) [2015-2020] [Andrew Annex]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/spiceypy/tests/gettestkernels.py
+++ b/spiceypy/tests/gettestkernels.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) [2015-2019] [Andrew Annex]
+Copyright (c) [2015-2020] [Andrew Annex]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/spiceypy/tests/test_gettestkernels.py
+++ b/spiceypy/tests/test_gettestkernels.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) [2015-2019] [Andrew Annex]
+Copyright (c) [2015-2020] [Andrew Annex]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/spiceypy/tests/test_spiceerrors.py
+++ b/spiceypy/tests/test_spiceerrors.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) [2015-2019] [Andrew Annex]
+Copyright (c) [2015-2020] [Andrew Annex]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/spiceypy/tests/test_support_types.py
+++ b/spiceypy/tests/test_support_types.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) [2015-2019] [Andrew Annex]
+Copyright (c) [2015-2020] [Andrew Annex]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/spiceypy/tests/test_wrapper.py
+++ b/spiceypy/tests/test_wrapper.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) [2015-2019] [Andrew Annex]
+Copyright (c) [2015-2020] [Andrew Annex]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/spiceypy/tests/test_wrapper.py
+++ b/spiceypy/tests/test_wrapper.py
@@ -717,7 +717,6 @@ def test_ckw03():
     work_quat = spice.m2q(work_mat)
     quats[0] = work_quat
     av[0] = [0.0, 0.0, RATE]
-    rates = [SECPERTICK] * MAXREC
     sclkdp = np.arange(MAXREC) * SPACING_TICKS
     sclkdp += 1000.0
     for i in range(1, MAXREC - 1):
@@ -986,12 +985,12 @@ def test_copy():
     cell_copy = spice.copy(out_cell)
     assert cell_copy.size >= 126
     assert cell_copy is not out_cell
-    assert cell_copy.dtype is 2
+    assert cell_copy.dtype == 2
     # SPICECHAR_CELL; dtype=0
     cell_src = spice.cell_char(10, 10)
     tmpRtn = [spice.appndc("{}".format(i), cell_src) for i in range(5)]
     cell_copy = spice.copy(cell_src)
-    assert cell_copy.dtype is 0
+    assert cell_copy.dtype == 0
     assert cell_copy.size == cell_src.size
     assert cell_copy.card == cell_src.card
     assert cell_copy[:] == cell_src[:]
@@ -1000,7 +999,7 @@ def test_copy():
     cell_src = spice.cell_double(10)
     tmpRtn = [spice.appndd(float(i), cell_src) for i in range(8)]
     cell_copy = spice.copy(cell_src)
-    assert cell_copy.dtype is 1
+    assert cell_copy.dtype == 1
     assert cell_copy.size == cell_src.size
     assert cell_copy.card == cell_src.card
     assert cell_copy[:] == cell_src[:]
@@ -1338,7 +1337,7 @@ def test_dafgsr():
         # * drec(3) NSUM Number of single summaries in this DAF record
         fward, bward, nSS = drec = map(int, spice.dafgsr(handle, iRecno, 1, 3))
         # There is only one summary record in de405s.bsp
-        assert iRecno == 7 and fward is 0 and bward is 0 and nSS == 15
+        assert iRecno == 7 and fward == 0 and bward == 0 and nSS == 15
         # Set index to first word of first summary
         firstWord = 4
         # Set DAF record before daf421.bsp next summary record's first record (641)
@@ -1468,7 +1467,7 @@ def test_dafrda():
     # * drec(3) NSUM Number of single summaries in this DAF record
     fward, bward, nSS = drec = map(int, spice.dafgsr(handle, iRecno, 1, 3))
     # There is only one summary record in de405s.bsp
-    assert iRecno == 7 and fward is 0 and bward is 0 and nSS == 15
+    assert iRecno == 7 and fward == 0 and bward == 0 and nSS == 15
     # Set index to first word of first summary
     firstWord = 4
     # Set DAF word before first segments first word (641 for de405s.bsp)
@@ -2210,9 +2209,6 @@ def test_dskxv_2():
     polmrg = 0.5
     latstp = 1.0
     lonstp = 2.0
-
-    nhits = 0
-    nderr = 0
 
     lon = -180.0
     lat = 90.0

--- a/spiceypy/utils/__init__.py
+++ b/spiceypy/utils/__init__.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) [2015-2019] [Andrew Annex]
+Copyright (c) [2015-2020] [Andrew Annex]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/spiceypy/utils/callbacks.py
+++ b/spiceypy/utils/callbacks.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) [2015-2019] [Andrew Annex]
+Copyright (c) [2015-2020] [Andrew Annex]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/spiceypy/utils/libspicehelper.py
+++ b/spiceypy/utils/libspicehelper.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) [2015-2019] [Andrew Annex]
+Copyright (c) [2015-2020] [Andrew Annex]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/spiceypy/utils/support_types.py
+++ b/spiceypy/utils/support_types.py
@@ -1,7 +1,7 @@
 """
 The MIT License (MIT)
 
-Copyright (c) [2015-2019] [Andrew Annex]
+Copyright (c) [2015-2020] [Andrew Annex]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
python 3.8 issues the SyntaxWarning below when the test_wrapper.py code is being compiled.
```
test_wrapper.py:1341: SyntaxWarning: "is" with a literal. Did you mean "=="?
```
This happens when using `is` identity check with literals (BPO issue: https://bugs.python.org/issue34850).