### PR TITLE
datetime2et: handle timezones correctly

### DIFF
--- a/spiceypy/tests/test_wrapper.py
+++ b/spiceypy/tests/test_wrapper.py
@@ -28,7 +28,7 @@ import pandas as pd
 import numpy as np
 import numpy.testing as npt
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 
 import spiceypy.utils.callbacks
 from spiceypy.tests.gettestkernels import (
@@ -9145,6 +9145,23 @@ def test_datetime2et():
     results = spice.datetime2et(dates)
     for expected, result in zip(expecteds, results):
         npt.assert_almost_equal(result, expected)
+
+    # same test, with timezone-aware datetimes
+    date = datetime(1997, 3, 20, 12, 53, 29, tzinfo=timezone.utc)
+    et = spice.datetime2et(date)
+    npt.assert_almost_equal(et, -87865528.8143913)
+
+    expecteds = [-87865528.8143913, -792086354.8170365, -790847954.8166842]
+    dates = [
+        datetime(1997, 3, 20, 12, 53, 29, tzinfo=timezone.utc),
+        datetime(1974, 11, 25, 20, 0, 0, tzinfo=timezone.utc),
+        datetime(1974, 12, 10, 4, 0, 0, tzinfo=timezone.utc),
+    ]
+
+    results = spice.datetime2et(dates)
+    for expected, result in zip(expecteds, results):
+        npt.assert_almost_equal(result, expected)
+
     spice.kclear()
 
 


### PR DESCRIPTION
The `datetime2et` function (added in #284) fails with a `SpiceyError` when using timezone-aware datetimes, because CSPICE always expects a UTC format without timezone information.

```
SPICE(INVALIDTIMESTRING) --
Time String Could Not Be Parsed
The input string contains an unrecognizable substring beginning at the character marked by <+>: "2020-01-01T00:00:00<+>00:00"
```

I have adjusted the implementation of `datetime2et` so that timezone-aware datetimes are converted to UTC if needed and then the `tzinfo` is dropped before passing on to SPICE.

Timezone-naive datetimes will still be assumed to be UTC, to stay consistent with the previous behavior. An alternative would be to interpret them as the system local time, which would be correct for use with e.g. `datetime.now()`, but not for `datetime.utcnow()`.