### PR TITLE
add et2datetime function

### DIFF
--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -41,7 +41,7 @@ from .utils.callbacks import (
 import functools
 import numpy
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 
 from numpy import ndarray, str_
 from spiceypy.utils.support_types import (
@@ -13255,6 +13255,25 @@ def datetime2et(dt: Union[Iterable[datetime], datetime]) -> Union[ndarray, float
         et = ctypes.c_double()
         libspice.utc2et_c(dt, ctypes.byref(et))
         return et.value
+
+
+@spice_error_check
+def et2datetime(et: Union[Iterable[float], float]) -> Union[ndarray, datetime]:
+    """
+    Convert an input time from ephemeris seconds past J2000 to
+    a standard Python datetime.
+
+    https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/time.html#The%20J2000%20Epoch
+
+    :param et: Input epoch, given in ephemeris seconds past J2000.
+    :return: Output datetime object in UTC
+    """
+    result = et2utc(et, 'ISOC', 6)
+    isoformat = '%Y-%m-%dT%H:%M:%S.%f'
+    if stypes.is_iterable(result):
+        return numpy.array([datetime.strptime(s, isoformat).replace(tzinfo=timezone.utc) for s in result])
+    else:
+        return datetime.strptime(result, isoformat).replace(tzinfo=timezone.utc)
 
 
 @spice_error_check

--- a/spiceypy/tests/test_wrapper.py
+++ b/spiceypy/tests/test_wrapper.py
@@ -28,7 +28,7 @@ import pandas as pd
 import numpy as np
 import numpy.testing as npt
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 
 import spiceypy.utils.callbacks
 from spiceypy.tests.gettestkernels import (
@@ -9145,6 +9145,27 @@ def test_datetime2et():
     results = spice.datetime2et(dates)
     for expected, result in zip(expecteds, results):
         npt.assert_almost_equal(result, expected)
+    spice.kclear()
+
+
+def test_et2datetime():
+    spice.kclear()
+    spice.furnsh(CoreKernels.testMetaKernel)
+    et = -87865528.8143913
+    dt = spice.et2datetime(et)
+    assert dt == datetime(1997, 3, 20, 12, 53, 29, tzinfo=timezone.utc)
+
+    expecteds = [
+        datetime(1997, 3, 20, 12, 53, 29, tzinfo=timezone.utc),
+        datetime(1974, 11, 25, 20, 0, 0, tzinfo=timezone.utc),
+        datetime(1974, 12, 10, 4, 0, 0, tzinfo=timezone.utc),
+    ]
+    ets = [-87865528.8143913, -792086354.8170365, -790847954.8166842]
+
+    results = spice.et2datetime(ets)
+    for expected, result in zip(expecteds, results):
+        assert result == expected
+
     spice.kclear()
 
 


### PR DESCRIPTION
There is already a `datetime2et` function to convert Python datetime objects to seconds past J2000 epoch, which was added in #284. However, the reverse function to convert ET to datetime was still missing.

I have implemented this `et2datetime` function, which first uses `et2utc` and then converts the resulting date strings into `datetime`s.