### PR TITLE
Fix internal reference in docs

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -4,7 +4,8 @@ Basics of SpiceyPy
 Environment Set-up
 ------------------
 
-Follow the installation instructions provided in :ref:`installation`.
+Follow the installation instructions provided in the :ref:`installation section
+<installation>`.
 
 Confirm SpiceyPy installation
 -----------------------------


### PR DESCRIPTION
Labels that are not placed before a section title need an explicit
title.
```
SpiceyPy/docs/basics.rst:7: WARNING: undefined label: installation (if the link has no caption the label must precede a section header)
```