### PR TITLE
Allow installation with existing cspice.tar.Z

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ matrix:
           python: 3.7
         - os: linux
           python: 3.8
+        - os: linux
+          python: 3.8
+          env: CSPICE_SRC_DIR="/tmp/cspice"
+        - os: linux
+          python: 3.8
+          env: CSPICE_SHARED_LIB="/tmp/cspice/lib/libcspice.so"
         - os: osx
           language: generic
           env: PYVERSION='3.6.2'
@@ -30,6 +36,8 @@ before_install:
 - pip install -U wheel
 - pip install twine
 - pip install -r requirements.txt
+- if ! [ -z "$CSPICE_SRC_DIR" ]; then wget -O - https://naif.jpl.nasa.gov/pub/naif/toolkit/C/PC_Linux_GCC_64bit/packages/cspice.tar.Z | gunzip -c | tar xC /tmp/ ; fi
+- if ! [ -z "$CSPICE_SHARED_LIB"]; then mkdir -p /tmp/cspice/ && wget -O - https://anaconda.org/conda-forge/cspice/66/download/linux-64/cspice-66-h516909a_1009.tar.bz2 | tar xjC /tmp/cspice/ ; fi
 install:
 - python setup.py install
 script:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -43,6 +43,28 @@ Or you can start a python interpreter and try importing SpiceyPy like so:
 This should print out the toolkit version without any errors. You have now
 verified that SpiceyPy is installed.
 
+Offline installation
+--------------------
+
+If you need to install SpiceyPy without a network or if you have a prebuilt shared library at hand,
+you can override the default behaviour of SpiceyPy by using the CSPICE_SRC_DIR and CSPICE_SHARED_LIB environment variables respectively.
+
+For example, if you have downloaded SpiceyPy and the CSPICE toolkit, and extracted CSPICE to /tmp/cspice you can run:
+
+.. code-block:: bash
+
+            export CSPICE_SRC_DIR="/tmp/cspice"
+            python setup.py install
+
+Or if you have a shared library of CSPICE located at /tmp/cspice.so, you can run:
+
+.. code-block:: bash
+
+            export CSPICE_SHARED_LIB="/tmp/cspice.so"
+            python setup.py install
+
+Both examples above assume you have cloned the SpiceyPy repository and are running those commands within the project directory.
+
 A simple example program
 ------------------------
 

--- a/get_spice.py
+++ b/get_spice.py
@@ -257,19 +257,35 @@ class InstallCSpice(object):
     @staticmethod
     def check_for_spice():
         print("Checking the path", cspice_dir)
-        if not os.path.exists(cspice_dir):
+        if os.path.exists(cspice_dir):
+            return False
 
-            message = "Unable to find CSPICE at {0}. Attempting to Download CSPICE For you:".format(
-                cspice_dir
-            )
-            print(message)
-            # Download cspice using getspice.py
-            GetCSPICE(version="N0066")
-            if not os.path.exists(cspice_dir):
-                message = "Unable to find CSPICE at {0}. Exiting".format(cspice_dir)
-                sys.exit(message)
+        try:
+            spiceypy_cspice_path = os.path.expanduser(os.environ['SPICEYPY_CSPICE_PATH'])
+            if not os.path.isabs(spiceypy_cspice_path):
+                raise EnvironmentError("spiceypy_cspice_path must be an absolute path. Got {0}".format(
+                    spiceypy_cspice_path))
+            print("Environment variable spiceypy_cspice_path is set. Installing CSPICE from {0}.".format(
+                spiceypy_cspice_path))
+            print("Unpacking cspice.")
+            untar_cmd = "tar xzf {0} -C {1}".format(spiceypy_cspice_path, root_dir)
+            proc = subprocess.Popen(untar_cmd, shell=True)
+            proc.wait()
+            print(f"Successfully unpacked CSPICE archive with return code {proc.returncode}")
             return True
-        return False
+        except KeyError as err:  # If environment variable is not set
+            pass
+
+        message = "Unable to find CSPICE at {0}. Attempting to Download CSPICE For you:".format(
+            cspice_dir
+        )
+        print(message)
+        # Download cspice using getspice.py
+        GetCSPICE(version="N0066")
+        if not os.path.exists(cspice_dir):
+            message = "Unable to find CSPICE at {0}. Exiting".format(cspice_dir)
+            sys.exit(message)
+        return True
 
     @staticmethod
     def unpack_cspice():


### PR DESCRIPTION
Add support for installing CSPICE from local directory, specified with environment variable SPICEYPY_CSPICE_PATH.

e.g. SPICEYPY_CSPICE_PATH=~/Downloads/cspice.tar.Z python setup.py install

Adresses  #349 