### PR TITLE
use datetime.fromisoformat instead of strptime

### DIFF
--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -13399,6 +13399,12 @@ def datetime2et(dt: Union[Iterable[datetime], datetime]) -> Union[ndarray, float
         return et.value
 
 
+if hasattr(datetime, 'fromisoformat'):
+    fromisoformat = lambda s: datetime.fromisoformat(s + '+00:00')
+else:
+    fromisoformat = lambda s: datetime.strptime(s, "%Y-%m-%dT%H:%M:%S.%f").replace(tzinfo=timezone.utc)
+
+
 @spice_error_check
 def et2datetime(et: Union[Iterable[float], float]) -> Union[ndarray, datetime]:
     """
@@ -13411,16 +13417,15 @@ def et2datetime(et: Union[Iterable[float], float]) -> Union[ndarray, datetime]:
     :return: Output datetime object in UTC
     """
     result = et2utc(et, "ISOC", 6)
-    isoformat = "%Y-%m-%dT%H:%M:%S.%f"
     if stypes.is_iterable(result):
         return numpy.array(
             [
-                datetime.strptime(s, isoformat).replace(tzinfo=timezone.utc)
+                fromisoformat(s)
                 for s in result
             ]
         )
     else:
-        return datetime.strptime(result, isoformat).replace(tzinfo=timezone.utc)
+        return fromisoformat(result)
 
 
 @spice_error_check

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -13400,9 +13400,11 @@ def datetime2et(dt: Union[Iterable[datetime], datetime]) -> Union[ndarray, float
 
 
 if hasattr(datetime, 'fromisoformat'):
-    fromisoformat = lambda s: datetime.fromisoformat(s + '+00:00')
+    def fromisoformat(s):
+        return datetime.fromisoformat(s + '+00:00')
 else:
-    fromisoformat = lambda s: datetime.strptime(s, "%Y-%m-%dT%H:%M:%S.%f").replace(tzinfo=timezone.utc)
+    def fromisoformat(s):
+        return datetime.strptime(s, "%Y-%m-%dT%H:%M:%S.%f").replace(tzinfo=timezone.utc)
 
 
 @spice_error_check
@@ -13418,12 +13420,7 @@ def et2datetime(et: Union[Iterable[float], float]) -> Union[ndarray, datetime]:
     """
     result = et2utc(et, "ISOC", 6)
     if stypes.is_iterable(result):
-        return numpy.array(
-            [
-                fromisoformat(s)
-                for s in result
-            ]
-        )
+        return numpy.array([fromisoformat(s) for s in result])
     else:
         return fromisoformat(result)
 


### PR DESCRIPTION
to improve performance of `et2datetime`.

The performance of the datetime parsing itself is enhanced by a factor of 100:
```python
timeit.timeit('datetime.datetime.strptime("2020-09-09T15:00:00.000", "%Y-%m-%dT%H:%M:%S.%f").replace(tzinfo=datetime.timezone.utc)', setup='import datetime')
>>> 10.533629100000013
timeit.timeit('datetime.datetime.fromisoformat("2020-09-09T15:00:00.000").replace(tzinfo=datetime.timezone.utc)', setup='import datetime')
>>> 1.2155922999999973
timeit.timeit('datetime.datetime.fromisoformat("2020-09-09T15:00:00.000+00:00")', setup='import datetime')
>>> 0.16864590000000135
```

This leads to a total performance improvement of ~60% for `et2datetime`:
```python
# before
timeit.timeit('spice.et2datetime(200)', setup='import spiceypy as spice; spice.furnsh("latest_leapseconds.tls")')
>>> 27.4600037
# after
timeit.timeit('spice.et2datetime(200)', setup='import spiceypy as spice; spice.furnsh("latest_leapseconds.tls")')
>>> 11.986385900000002
```

`datetime.fromisoformat` is only available since Python 3.7, I added a fallback to `strptime` for Python 3.6.