### PR TITLE
trying to make sdist/bdist work better

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,7 +7,7 @@ include requirements.txt
 include README.rst
 
 # cspice files
-include spiceypy/utils/*
+include spiceypy/utils/*.py
 
 # Docs
 include docs/conf.py


### PR DESCRIPTION
sdist would include spice.so for sdist, which is definitely wrong. bdist/bdist_wheel should be the only thing that includes the shared library.


 should fix #394 