### PR TITLE
Simplifying functions with ncol/nrow params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ spiceypy/utils/__pycache__/
 *.whl
 .pytest_cache/
 *.sqlite3
+/badhashkernel.txt

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -2408,7 +2408,7 @@ def dgeodr(x: float, y: float, z: float, re: float, f: float) -> ndarray:
 
 
 @spice_error_check
-def diags2(symmat: Iterable[Iterable[float]]) -> Tuple[ndarray, ndarray]:
+def diags2(symmat: Union[ndarray, Iterable[Iterable[float]]]) -> Tuple[ndarray, ndarray]:
     """
     Diagonalize a symmetric 2x2 matrix.
 
@@ -8630,7 +8630,7 @@ def lxqstr(string: str, qchar: str, first: int) -> Tuple[int, int]:
 
 @spice_error_check
 def m2eul(
-    r: Iterable[Iterable[float]], axis3: int, axis2: int, axis1: int
+    r: Union[ndarray, Iterable[Iterable[float]]], axis3: int, axis2: int, axis1: int
 ) -> Tuple[float, float, float]:
     """
     Factor a rotation matrix as a product of three rotations
@@ -8792,20 +8792,19 @@ def mtxm(m1: ndarray, m2: ndarray) -> ndarray:
 
 
 @spice_error_check
-def mtxmg(m1: ndarray, m2: ndarray, ncol1: int, nr1r2: int, ncol2: int) -> ndarray:
+def mtxmg(m1: ndarray, m2: ndarray) -> ndarray:
     """
     Multiply the transpose of a matrix with
     another matrix, both of arbitrary size.
 
     https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/mtxmg_c.html
 
-    :param m1: nr1r2 X ncol1 double precision matrix.
-    :param m2: nr1r2 X ncol2 double precision matrix.
-    :param ncol1: Column dimension of m1 and row dimension of mout.
-    :param nr1r2: Row dimension of m1 and m2.
-    :param ncol2: Column dimension of m2.
-    :return: Transpose of m1 times m2.
+    :param m1: N x M double precision matrix.
+    :param m2: N x O double precision matrix.
+    :return: Transpose of m1 times m2 (O x M).
     """
+    ncol1, ncol2 = len(m1[0]), len(m2[0])
+    nr1r2 = len(m1)
     m1 = stypes.to_double_matrix(m1)
     m2 = stypes.to_double_matrix(m2)
     mout = stypes.empty_double_matrix(x=ncol2, y=ncol1)
@@ -8836,7 +8835,7 @@ def mtxv(m1: ndarray, vin: ndarray) -> ndarray:
 
 
 @spice_error_check
-def mtxvg(m1: ndarray, v2: ndarray, ncol1: int, nr1r2: int) -> ndarray:
+def mtxvg(m1: ndarray, v2: ndarray) -> ndarray:
     """
     Multiply the transpose of a matrix and
     a vector of arbitrary size.
@@ -8845,10 +8844,10 @@ def mtxvg(m1: ndarray, v2: ndarray, ncol1: int, nr1r2: int) -> ndarray:
 
     :param m1: Left-hand matrix to be multiplied.
     :param v2: Right-hand vector to be multiplied.
-    :param ncol1: Column dimension of m1 and length of vout.
-    :param nr1r2: Row dimension of m1 and length of v2.
     :return: Product vector m1 transpose * v2.
     """
+    ncol1 = len(m1[0])
+    nr1r2 = len(v2)
     m1 = stypes.to_double_matrix(m1)
     v2 = stypes.to_double_vector(v2)
     ncol1 = ctypes.c_int(ncol1)
@@ -8859,7 +8858,7 @@ def mtxvg(m1: ndarray, v2: ndarray, ncol1: int, nr1r2: int) -> ndarray:
 
 
 @spice_error_check
-def mxm(m1: Iterable[Iterable[float]], m2: Iterable[Iterable[float]]) -> ndarray:
+def mxm(m1: Union[ndarray, Iterable[Iterable[float]]], m2: Union[ndarray, Iterable[Iterable[float]]]) -> ndarray:
     """
     Multiply two 3x3 matrices.
 
@@ -8878,11 +8877,8 @@ def mxm(m1: Iterable[Iterable[float]], m2: Iterable[Iterable[float]]) -> ndarray
 
 @spice_error_check
 def mxmg(
-    m1: Iterable[Iterable[float]],
-    m2: Iterable[Iterable[float]],
-    nrow1: int,
-    ncol1: int,
-    ncol2: int,
+    m1: Union[ndarray, Iterable[Iterable[float]]],
+    m2: Union[ndarray, Iterable[Iterable[float]]],
 ) -> ndarray:
     """
     Multiply two double precision matrices of arbitrary size.
@@ -8891,11 +8887,9 @@ def mxmg(
 
     :param m1: nrow1 X ncol1 double precision matrix.
     :param m2: ncol1 X ncol2 double precision matrix.
-    :param nrow1: Row dimension of m1
-    :param ncol1: Column dimension of m1 and row dimension of m2.
-    :param ncol2: Column dimension of m2
     :return: nrow1 X ncol2 double precision matrix.
     """
+    nrow1, ncol1, ncol2 = len(m1), len(m1[0]), len(m2[0])
     m1 = stypes.to_double_matrix(m1)
     m2 = stypes.to_double_matrix(m2)
     mout = stypes.empty_double_matrix(x=ncol2, y=nrow1)
@@ -8907,7 +8901,7 @@ def mxmg(
 
 
 @spice_error_check
-def mxmt(m1: Iterable[Iterable[float]], m2: Iterable[Iterable[float]]) -> ndarray:
+def mxmt(m1: Union[ndarray, Iterable[Iterable[float]]], m2: Union[ndarray, Iterable[Iterable[float]]]) -> ndarray:
     """
     Multiply a 3x3 matrix and the transpose of another 3x3 matrix.
 
@@ -10165,7 +10159,7 @@ def radrec(inrange: float, re: float, dec: float) -> ndarray:
 
 
 @spice_error_check
-def rav2xf(rot: Iterable[Iterable[float]], av: Iterable[float]) -> ndarray:
+def rav2xf(rot: Union[ndarray, Iterable[Iterable[float]]], av: Iterable[float]) -> ndarray:
     """
     This routine determines a state transformation matrix
     from a rotation matrix and the angular velocity of the
@@ -12481,7 +12475,7 @@ def spkw05(
     segid: str,
     gm: float,
     n: int,
-    states: Iterable[Iterable[float]],
+    states: Union[ndarray, Iterable[Iterable[float]]],
     epochs: Iterable[float],
 ) -> None:
     # see libspice args for solution to array[][N] problem
@@ -12531,7 +12525,7 @@ def spkw08(
     segid: str,
     degree: int,
     n: int,
-    states: Iterable[Iterable[float]],
+    states: Union[ndarray, Iterable[Iterable[float]]],
     epoch1: float,
     step: float,
 ) -> None:
@@ -12593,7 +12587,7 @@ def spkw09(
     segid: str,
     degree: int,
     n: int,
-    states: Iterable[Iterable[float]],
+    states: Union[ndarray, Iterable[Iterable[float]]],
     epochs: Iterable[float],
 ) -> None:
     """
@@ -12688,7 +12682,7 @@ def spkw12(
     segid: str,
     degree: int,
     n: int,
-    states: Iterable[Iterable[float]],
+    states: Union[ndarray, Iterable[Iterable[float]]],
     epoch0: float,
     step: float,
 ) -> None:
@@ -12749,7 +12743,7 @@ def spkw13(
     segid: str,
     degree: int,
     n: int,
-    states: Iterable[Iterable[float]],
+    states: Union[ndarray, Iterable[Iterable[float]]],
     epochs: Iterable[float],
 ) -> None:
     """
@@ -14113,7 +14107,7 @@ def tpictr(
 
 
 @spice_error_check
-def trace(matrix: Iterable[Iterable[float]]) -> float:
+def trace(matrix: Union[ndarray, Iterable[Iterable[float]]]) -> float:
     """
     Return the trace of a 3x3 matrix.
 
@@ -15158,7 +15152,7 @@ def vtmv(v1: ndarray, matrix: ndarray, v2: ndarray) -> float:
 
 
 @spice_error_check
-def vtmvg(v1: ndarray, matrix: ndarray, v2: ndarray, nrow: int, ncol: int) -> float:
+def vtmvg(v1: ndarray, matrix: ndarray, v2: ndarray) -> float:
     """
     Multiply the transpose of a n-dimensional
     column vector a nxm matrix,
@@ -15173,6 +15167,7 @@ def vtmvg(v1: ndarray, matrix: ndarray, v2: ndarray, nrow: int, ncol: int) -> fl
     :param ncol: Number of columns in matrix (number of rows in v2.)
     :return: the result of (v1**t * matrix * v2 )
     """
+    nrow, ncol = len(v1), len(v2)
     v1 = stypes.to_double_vector(v1)
     matrix = stypes.to_double_matrix(matrix)
     v2 = stypes.to_double_vector(v2)
@@ -15700,7 +15695,7 @@ def xpose(m: Union[ndarray, Iterable[Iterable[float]]]) -> ndarray:
 
 
 @spice_error_check
-def xpose6(m: Iterable[Iterable[float]]) -> ndarray:
+def xpose6(m: Union[ndarray, Iterable[Iterable[float]]]) -> ndarray:
     """
     Transpose a 6x6 matrix
 
@@ -15716,9 +15711,7 @@ def xpose6(m: Iterable[Iterable[float]]) -> ndarray:
 
 
 @spice_error_check
-def xposeg(
-    matrix: Union[ndarray, Iterable[Iterable[float]]], nrow: int, ncol: int
-) -> ndarray:
+def xposeg(matrix: Union[ndarray, Iterable[Iterable[float]]]) -> ndarray:
     """
     Transpose a matrix of arbitrary size
     in place, the matrix need not be square.
@@ -15730,6 +15723,7 @@ def xposeg(
     :param ncol: Number of columns of input matrix
     :return: Transposed matrix
     """
+    ncol, nrow = len(matrix[0]), len(matrix)
     matrix = stypes.to_double_matrix(matrix)
     mout = stypes.empty_double_matrix(x=ncol, y=nrow)
     ncol = ctypes.c_int(ncol)

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -8871,7 +8871,9 @@ def mtxv(m1: ndarray, vin: ndarray) -> ndarray:
 
 
 @spice_error_check
-def mtxvg(m1: ndarray, v2: ndarray, ncol1: OptionalInt = None, nr1r2: OptionalInt = None) -> ndarray:
+def mtxvg(
+    m1: ndarray, v2: ndarray, ncol1: OptionalInt = None, nr1r2: OptionalInt = None
+) -> ndarray:
     """
     Multiply the transpose of a matrix and
     a vector of arbitrary size.
@@ -15256,7 +15258,13 @@ def vtmv(v1: ndarray, matrix: ndarray, v2: ndarray) -> float:
 
 
 @spice_error_check
-def vtmvg(v1: ndarray, matrix: ndarray, v2: ndarray, nrow: OptionalInt = None, ncol: OptionalInt = None) -> float:
+def vtmvg(
+    v1: ndarray,
+    matrix: ndarray,
+    v2: ndarray,
+    nrow: OptionalInt = None,
+    ncol: OptionalInt = None,
+) -> float:
     """
     Multiply the transpose of a n-dimensional
     column vector a nxm matrix,
@@ -15817,7 +15825,9 @@ def xpose6(m: Union[ndarray, Iterable[Iterable[float]]]) -> ndarray:
 
 @spice_error_check
 def xposeg(
-    matrix: Union[ndarray, Iterable[Iterable[float]]], nrow: OptionalInt = None, ncol: OptionalInt = None
+    matrix: Union[ndarray, Iterable[Iterable[float]]],
+    nrow: OptionalInt = None,
+    ncol: OptionalInt = None,
 ) -> ndarray:
     """
     Transpose a matrix of arbitrary size
@@ -15833,7 +15843,7 @@ def xposeg(
     warn_depricated_args(nrow=nrow, ncol=ncol)
     ncol, nrow = len(matrix[0]), len(matrix)
     matrix = stypes.to_double_matrix(matrix)
-    mout = stypes.empty_double_matrix(x=ncol, y=nrow)
+    mout = stypes.empty_double_matrix(x=nrow, y=ncol)
     ncol = ctypes.c_int(ncol)
     nrow = ctypes.c_int(nrow)
     libspice.xposeg_c(matrix, nrow, ncol, mout)

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -8921,8 +8921,8 @@ def mxm(
 
 @spice_error_check
 def mxmg(
-    m1: Iterable[Iterable[float]],
-    m2: Iterable[Iterable[float]],
+    m1: Union[ndarray, Iterable[Iterable[float]]],
+    m2: Union[ndarray, Iterable[Iterable[float]]],
     nrow1: OptionalInt = None,
     ncol1: OptionalInt = None,
     ncol2: OptionalInt = None,
@@ -8973,7 +8973,7 @@ def mxmt(
 
 
 @spice_error_check
-def mxmtg(m1: ndarray, m2: ndarray, nrow1: int, nc1c2: int, nrow2: int) -> ndarray:
+def mxmtg(m1: Union[ndarray, Iterable[Iterable[float]]], m2: Union[ndarray, Iterable[Iterable[float]]], nrow1: OptionalInt = None, nc1c2: OptionalInt = None, nrow2: OptionalInt = None) -> ndarray:
     """
     Multiply a matrix and the transpose of a matrix, both of arbitrary size.
 
@@ -8986,6 +8986,8 @@ def mxmtg(m1: ndarray, m2: ndarray, nrow1: int, nc1c2: int, nrow2: int) -> ndarr
     :param nrow2: Row dimension of m2 and column dimension of mout.
     :return: Product matrix.
     """
+    warn_depricated_args(nrow1=nrow1, nc1c2=nc1c2, nrow2=nrow2)
+    nrow1, nc1c2, nrow2 = len(m1), len(m1[0]), len(m2)
     m1 = stypes.to_double_matrix(m1)
     m2 = stypes.to_double_matrix(m2)
     mout = stypes.empty_double_matrix(x=nrow2, y=nrow1)
@@ -9016,7 +9018,7 @@ def mxv(m1: ndarray, vin: ndarray) -> ndarray:
 
 
 @spice_error_check
-def mxvg(m1: ndarray, v2: ndarray, nrow1: int, nc1r2: int) -> ndarray:
+def mxvg(m1: Union[ndarray, Iterable[Iterable[float]]], v2: Union[ndarray, Iterable[Iterable[float]]], nrow1: OptionalInt = None, nc1r2: OptionalInt = None) -> ndarray:
     """
     Multiply a matrix and a vector of arbitrary size.
 
@@ -9028,6 +9030,8 @@ def mxvg(m1: ndarray, v2: ndarray, nrow1: int, nc1r2: int) -> ndarray:
     :param nc1r2: Column dimension of m1 and length of v2.
     :return: Product vector m1*v2
     """
+    warn_depricated_args(nrow1=nrow1, nc1r2=nc1r2)
+    nrow1, nc1r2 = len(m1), len(m1[0])
     m1 = stypes.to_double_matrix(m1)
     v2 = stypes.to_double_vector(v2)
     nrow1 = ctypes.c_int(nrow1)

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -681,7 +681,7 @@ def bschoc(
     ndim: int,
     lenvals: int,
     array: Union[ndarray, Iterable[str]],
-    order: Iterable[int],
+    order: Union[ndarray, Iterable[int]],
 ) -> int:
     """
     Do a binary search for a given value within a character string array,
@@ -706,7 +706,12 @@ def bschoc(
 
 
 @spice_error_check
-def bschoi(value: int, ndim: int, array: Iterable[int], order: Iterable[int]) -> int:
+def bschoi(
+    value: int,
+    ndim: int,
+    array: Union[ndarray, Iterable[int]],
+    order: Union[ndarray, Iterable[int]],
+) -> int:
     """
     Do a binary search for a given value within an integer array,
     accompanied by an order vector.  Return the index of the
@@ -852,7 +857,7 @@ def ccifrm(
 
 @spice_error_check
 def cgv2el(
-    center: Iterable[float],
+    center: Union[ndarray, Iterable[float]],
     vec1: Union[ndarray, Iterable[float]],
     vec2: Union[ndarray, Iterable[float]],
 ) -> Ellipse:
@@ -876,7 +881,11 @@ def cgv2el(
 
 @spice_error_check
 def chbder(
-    cp: Iterable[float], degp: int, x2s: Iterable[float], x: float, nderiv: int
+    cp: Union[ndarray, Iterable[float]],
+    degp: int,
+    x2s: Union[ndarray, Iterable[float]],
+    x: float,
+    nderiv: int,
 ) -> ndarray:
     """
     Given the coefficients for the Chebyshev expansion of a
@@ -1234,7 +1243,7 @@ def ckw02(
     stop: ndarray,
     quats: ndarray,
     avvs: ndarray,
-    rates: Iterable[float],
+    rates: Union[ndarray, Iterable[float]],
 ) -> None:
     """
     Write a type 2 segment to a C-kernel.
@@ -1285,7 +1294,7 @@ def ckw03(
     quats: ndarray,
     avvs: ndarray,
     nints: int,
-    starts: Iterable[float],
+    starts: Union[ndarray, Iterable[float]],
 ) -> None:
     """
     Add a type 3 segment to a C-kernel.
@@ -3723,7 +3732,7 @@ def ekaced(
     recno: int,
     column: str,
     nvals: int,
-    dvals: Iterable[float],
+    dvals: Union[ndarray, Iterable[float]],
     isnull: bool,
 ) -> None:
     """
@@ -3756,7 +3765,7 @@ def ekacei(
     recno: int,
     column: str,
     nvals: int,
-    ivals: Iterable[int],
+    ivals: Union[ndarray, Iterable[int]],
     isnull: bool,
 ) -> None:
     """
@@ -3789,10 +3798,10 @@ def ekaclc(
     column: str,
     vallen: int,
     cvals: Iterable[str],
-    entszs: Iterable[int],
+    entszs: Union[ndarray, Iterable[int]],
     nlflgs: Iterable[bool],
     rcptrs: ndarray,
-    wkindx: Iterable[int],
+    wkindx: Union[ndarray, Iterable[int]],
 ) -> ndarray:
     """
     Add an entire character column to an EK segment.
@@ -3830,11 +3839,11 @@ def ekacld(
     handle: int,
     segno: int,
     column: str,
-    dvals: Iterable[float],
-    entszs: Iterable[int],
+    dvals: Union[ndarray, Iterable[float]],
+    entszs: Union[ndarray, Iterable[int]],
     nlflgs: Iterable[bool],
     rcptrs: ndarray,
-    wkindx: Iterable[int],
+    wkindx: Union[ndarray, Iterable[int]],
 ) -> ndarray:
     """
     Add an entire double precision column to an EK segment.
@@ -3868,11 +3877,11 @@ def ekacli(
     handle: int,
     segno: int,
     column: str,
-    ivals: Iterable[int],
-    entszs: Iterable[int],
+    ivals: Union[ndarray, Iterable[int]],
+    entszs: Union[ndarray, Iterable[int]],
     nlflgs: Iterable[bool],
     rcptrs: ndarray,
-    wkindx: Iterable[int],
+    wkindx: Union[ndarray, Iterable[int]],
 ) -> ndarray:
     """
     Add an entire integer column to an EK segment.
@@ -4635,7 +4644,7 @@ def ekuced(
     recno: int,
     column: str,
     nvals: int,
-    dvals: Iterable[float],
+    dvals: Union[ndarray, Iterable[float]],
     isnull: bool,
 ) -> None:
     """
@@ -4668,7 +4677,7 @@ def ekucei(
     recno: int,
     column: str,
     nvals: int,
-    ivals: Iterable[int],
+    ivals: Union[ndarray, Iterable[int]],
     isnull: bool,
 ) -> None:
     """
@@ -5227,7 +5236,7 @@ def fn2lun(fname: str) -> int:
 @spice_error_check
 def fovray(
     inst: str,
-    raydir: Iterable[float],
+    raydir: Union[ndarray, Iterable[float]],
     rframe: str,
     abcorr: str,
     observer: str,
@@ -5307,7 +5316,7 @@ def fovtrg(
 
 
 @spice_error_check
-def frame(x: Iterable[float]) -> Tuple[ndarray, ndarray, ndarray]:
+def frame(x: Union[ndarray, Iterable[float]]) -> Tuple[ndarray, ndarray, ndarray]:
     """
     https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/frame_c.html
 
@@ -5697,9 +5706,9 @@ def gfevnt(
     lenvals: int,
     qpnams: Iterable[str],
     qcpars: Iterable[str],
-    qdpars: Iterable[float],
-    qipars: Iterable[int],
-    qlpars: Iterable[int],
+    qdpars: Union[ndarray, Iterable[float]],
+    qipars: Union[ndarray, Iterable[int]],
+    qlpars: Union[ndarray, Iterable[int]],
     op: str,
     refval: float,
     tol: float,
@@ -5798,7 +5807,7 @@ def gfevnt(
 def gffove(
     inst: str,
     tshape: str,
-    raydir: Iterable[float],
+    raydir: Union[ndarray, Iterable[float]],
     target: str,
     tframe: str,
     abcorr: str,
@@ -5891,7 +5900,7 @@ def gfilum(
     fixref: str,
     abcorr: str,
     obsrvr: str,
-    spoint: Iterable[float],
+    spoint: Union[ndarray, Iterable[float]],
     relate: str,
     refval: float,
     adjust: float,
@@ -6556,7 +6565,7 @@ def gfsntc(
     abcorr: str,
     obsrvr: str,
     dref: str,
-    dvec: Iterable[float],
+    dvec: Union[ndarray, Iterable[float]],
     crdsys: str,
     coord: str,
     relate: str,
@@ -7580,7 +7589,7 @@ def irftrn(refa: str, refb: str) -> ndarray:
 
 
 @spice_error_check
-def isordv(array: Iterable[int], n: int) -> bool:
+def isordv(array: Union[ndarray, Iterable[int]], n: int) -> bool:
     """
     Determine whether an array of n items contains the integers
     0 through n-1.
@@ -7623,7 +7632,7 @@ def isrchc(value: str, ndim: int, lenvals: int, array: Iterable[str]) -> int:
 
 
 @spice_error_check
-def isrchd(value: float, ndim: int, array: Iterable[float]) -> int:
+def isrchd(value: float, ndim: int, array: Union[ndarray, Iterable[float]]) -> int:
     """
     Search for a given value within a double precision array. Return
     the index of the first matching array entry, or -1 if the key value
@@ -7645,7 +7654,7 @@ def isrchd(value: float, ndim: int, array: Iterable[float]) -> int:
 
 
 @spice_error_check
-def isrchi(value: int, ndim: int, array: Iterable[int]) -> int:
+def isrchi(value: int, ndim: int, array: Union[ndarray, Iterable[int]]) -> int:
     """
     Search for a given value within an integer array. Return
     the index of the first matching array entry, or -1 if the key
@@ -8160,7 +8169,7 @@ def limbpt(
     abcorr: str,
     corloc: str,
     obsrvr: str,
-    refvec: Iterable[float],
+    refvec: Union[ndarray, Iterable[float]],
     rolstp: float,
     ncuts: int,
     schstp: float,
@@ -8398,7 +8407,7 @@ def lstlec(string: str, n: int, lenvals: int, array: Iterable[str]) -> int:
 
 
 @spice_error_check
-def lstled(x: float, n: int, array: Iterable[float]) -> int:
+def lstled(x: float, n: int, array: Union[ndarray, Iterable[float]]) -> int:
     """
     Given a number x and an array of non-decreasing floats
     find the index of the largest array element less than or equal to x.
@@ -8417,7 +8426,7 @@ def lstled(x: float, n: int, array: Iterable[float]) -> int:
 
 
 @spice_error_check
-def lstlei(x: int, n: int, array: Iterable[int]) -> int:
+def lstlei(x: int, n: int, array: Union[ndarray, Iterable[int]]) -> int:
     """
     Given a number x and an array of non-decreasing ints,
     find the index of the largest array element less than or equal to x.
@@ -8460,7 +8469,7 @@ def lstltc(string: str, n: int, lenvals: int, array: Iterable[str]) -> int:
 
 
 @spice_error_check
-def lstltd(x: float, n: int, array: Iterable[float]) -> int:
+def lstltd(x: float, n: int, array: Union[ndarray, Iterable[float]]) -> int:
     """
     Given a number x and an array of non-decreasing floats
     find the index of the largest array element less than x.
@@ -8479,7 +8488,7 @@ def lstltd(x: float, n: int, array: Iterable[float]) -> int:
 
 
 @spice_error_check
-def lstlti(x: int, n: int, array: Iterable[int]) -> int:
+def lstlti(x: int, n: int, array: Union[ndarray, Iterable[int]]) -> int:
     """
     Given a number x and an array of non-decreasing int,
     find the index of the largest array element less than x.
@@ -9053,7 +9062,7 @@ def ncposr(string: str, chars: str, start: int) -> int:
 
 @spice_error_check
 def nearpt(
-    positn: Iterable[float], a: float, b: float, c: float
+    positn: Union[ndarray, Iterable[float]], a: float, b: float, c: float
 ) -> Tuple[ndarray, float]:
     """
     locates the point on the surface of an ellipsoid that is nearest to a
@@ -9082,7 +9091,11 @@ def nearpt(
 
 @spice_error_check
 def npedln(
-    a: float, b: float, c: float, linept: Iterable[float], linedr: Iterable[float]
+    a: float,
+    b: float,
+    c: float,
+    linept: Union[ndarray, Iterable[float]],
+    linedr: Union[ndarray, Iterable[float]],
 ) -> Tuple[ndarray, float]:
     """
     Find nearest point on a triaxial ellipsoid to a specified
@@ -9109,7 +9122,9 @@ def npedln(
 
 
 @spice_error_check
-def npelpt(point: Iterable[float], ellips: Ellipse) -> Tuple[ndarray, float]:
+def npelpt(
+    point: Union[ndarray, Iterable[float]], ellips: Ellipse
+) -> Tuple[ndarray, float]:
     """
     Find the nearest point on an ellipse to a specified point, both
     in three-dimensional space, and find the distance between the
@@ -9130,7 +9145,9 @@ def npelpt(point: Iterable[float], ellips: Ellipse) -> Tuple[ndarray, float]:
 
 @spice_error_check
 def nplnpt(
-    linpt: Iterable[float], lindir: Iterable[float], point: Iterable[float]
+    linpt: Union[ndarray, Iterable[float]],
+    lindir: Union[ndarray, Iterable[float]],
+    point: Union[ndarray, Iterable[float]],
 ) -> Tuple[ndarray, float]:
     """
     Find the nearest point on a line to a specified point,
@@ -9173,7 +9190,9 @@ def nvc2pl(normal: Union[Iterable[float], Iterable[float]], constant: float) -> 
 
 
 @spice_error_check
-def nvp2pl(normal: Iterable[float], point: Iterable[float]) -> Plane:
+def nvp2pl(
+    normal: Union[ndarray, Iterable[float]], point: Union[ndarray, Iterable[float]]
+) -> Plane:
     """
     Make a plane from a normal vector and a point.
 
@@ -9530,7 +9549,7 @@ def pckw02(
     intlen: float,
     n: int,
     polydg: int,
-    cdata: Iterable[float],
+    cdata: Union[ndarray, Iterable[float]],
     btime: float,
 ) -> None:
     """
@@ -9807,10 +9826,10 @@ def pltexp(
 
 @spice_error_check
 def pltnp(
-    point: Iterable[float],
-    v1: Iterable[float],
-    v2: Iterable[float],
-    v3: Iterable[float],
+    point: Union[ndarray, Iterable[float]],
+    v1: Union[ndarray, Iterable[float]],
+    v2: Union[ndarray, Iterable[float]],
+    v3: Union[ndarray, Iterable[float]],
 ) -> Tuple[ndarray, float]:
     """
     Find the nearest point on a triangular plate to a given point.
@@ -9836,7 +9855,7 @@ def pltnp(
 @spice_error_check
 def pltnrm(
     v1: Iterable[Union[float, float]],
-    v2: Iterable[float],
+    v2: Union[ndarray, Iterable[float]],
     v3: Iterable[Union[float, float]],
 ) -> ndarray:
     """
@@ -9878,7 +9897,9 @@ def pltvol(vrtces: Sequence[Iterable[float]], plates: Sequence[Iterable[int]]) -
 
 
 @spice_error_check
-def polyds(coeffs: Iterable[float], deg: int, nderiv: int, t: int) -> ndarray:
+def polyds(
+    coeffs: Union[ndarray, Iterable[float]], deg: int, nderiv: int, t: int
+) -> ndarray:
     """
     Compute the value of a polynomial and it's first
     n derivatives at the value t.
@@ -10105,7 +10126,7 @@ def qcktrc(tracelen: int = _default_len_out) -> str:
 
 
 @spice_error_check
-def qdq2av(q: ndarray, dq: Iterable[float]) -> ndarray:
+def qdq2av(q: ndarray, dq: Union[ndarray, Iterable[float]]) -> ndarray:
     """
     Derive angular velocity from a unit quaternion and its derivative
     with respect to time.
@@ -10124,7 +10145,9 @@ def qdq2av(q: ndarray, dq: Iterable[float]) -> ndarray:
 
 
 @spice_error_check
-def qxq(q1: Union[ndarray, Iterable[float]], q2: Iterable[float]) -> ndarray:
+def qxq(
+    q1: Union[ndarray, Iterable[float]], q2: Union[ndarray, Iterable[float]]
+) -> ndarray:
     """
     Multiply two quaternions.
 
@@ -10168,7 +10191,7 @@ def radrec(inrange: float, re: float, dec: float) -> ndarray:
 
 @spice_error_check
 def rav2xf(
-    rot: Union[ndarray, Iterable[Iterable[float]]], av: Iterable[float]
+    rot: Union[ndarray, Iterable[Iterable[float]]], av: Union[ndarray, Iterable[float]]
 ) -> ndarray:
     """
     This routine determines a state transformation matrix
@@ -10228,7 +10251,7 @@ def rdtext(
 
 
 @spice_error_check
-def reccyl(rectan: Iterable[float]) -> Tuple[float, float, float]:
+def reccyl(rectan: Union[ndarray, Iterable[float]]) -> Tuple[float, float, float]:
     """
     Convert from rectangular to cylindrical coordinates.
 
@@ -10249,7 +10272,9 @@ def reccyl(rectan: Iterable[float]) -> Tuple[float, float, float]:
 
 
 @spice_error_check
-def recgeo(rectan: Iterable[float], re: float, f: float) -> Tuple[float, float, float]:
+def recgeo(
+    rectan: Union[ndarray, Iterable[float]], re: float, f: float
+) -> Tuple[float, float, float]:
     """
     Convert from rectangular coordinates to geodetic coordinates.
 
@@ -10425,7 +10450,7 @@ def removi(item: int, inset: SpiceCell) -> None:
 
 @spice_error_check
 def reordc(
-    iorder: Iterable[int], ndim: int, lenvals: int, array: Iterable[str]
+    iorder: Union[ndarray, Iterable[int]], ndim: int, lenvals: int, array: Iterable[str]
 ) -> Iterable[str]:
     """
     Re-order the elements of an array of character strings
@@ -10448,7 +10473,11 @@ def reordc(
 
 
 @spice_error_check
-def reordd(iorder: Iterable[int], ndim: int, array: Iterable[float]) -> ndarray:
+def reordd(
+    iorder: Union[ndarray, Iterable[int]],
+    ndim: int,
+    array: Union[ndarray, Iterable[float]],
+) -> ndarray:
     """
     Re-order the elements of a double precision array according to
     a given order vector.
@@ -10468,7 +10497,11 @@ def reordd(iorder: Iterable[int], ndim: int, array: Iterable[float]) -> ndarray:
 
 
 @spice_error_check
-def reordi(iorder: Iterable[int], ndim: int, array: Iterable[int]) -> ndarray:
+def reordi(
+    iorder: Union[ndarray, Iterable[int]],
+    ndim: int,
+    array: Union[ndarray, Iterable[int]],
+) -> ndarray:
     """
     Re-order the elements of an integer array according to
     a given order vector.
@@ -10488,7 +10521,9 @@ def reordi(iorder: Iterable[int], ndim: int, array: Iterable[int]) -> ndarray:
 
 
 @spice_error_check
-def reordl(iorder: Iterable[int], ndim: int, array: Iterable[bool]) -> ndarray:
+def reordl(
+    iorder: Union[ndarray, Iterable[int]], ndim: int, array: Iterable[bool]
+) -> ndarray:
     """
     Re-order the elements of a logical (Boolean) array according to
     a given order vector.
@@ -10791,7 +10826,9 @@ def rquad(a: float, b: float, c: float) -> Tuple[ndarray, ndarray]:
 
 
 @spice_error_check
-def saelgv(vec1: Iterable[float], vec2: Iterable[float]) -> Tuple[ndarray, ndarray]:
+def saelgv(
+    vec1: Union[ndarray, Iterable[float]], vec2: Union[ndarray, Iterable[float]]
+) -> Tuple[ndarray, ndarray]:
     """
     Find semi-axis vectors of an ellipse generated by two arbitrary
     three-dimensional vectors.
@@ -11137,7 +11174,7 @@ def shellc(ndim: int, lenvals: int, array: Iterable[str]) -> Iterable[str]:
 
 
 @spice_error_check
-def shelld(ndim: int, array: Iterable[float]) -> ndarray:
+def shelld(ndim: int, array: Union[ndarray, Iterable[float]]) -> ndarray:
     # Works!, use this as example for "I/O" parameters
     """
     Sort a double precision array using the Shell Sort algorithm.
@@ -11155,7 +11192,7 @@ def shelld(ndim: int, array: Iterable[float]) -> ndarray:
 
 
 @spice_error_check
-def shelli(ndim: int, array: Iterable[int]) -> ndarray:
+def shelli(ndim: int, array: Union[ndarray, Iterable[int]]) -> ndarray:
     # Works!, use this as example for "I/O" parameters
     """
     Sort an integer array using the Shell Sort algorithm.
@@ -11506,7 +11543,10 @@ def spkaps(
 
 @spice_error_check
 def spk14a(
-    handle: int, ncsets: int, coeffs: Iterable[float], epochs: Iterable[float]
+    handle: int,
+    ncsets: int,
+    coeffs: Union[ndarray, Iterable[float]],
+    epochs: Union[ndarray, Iterable[float]],
 ) -> None:
     """
     Add data to a type 14 SPK segment associated with handle. See
@@ -11620,7 +11660,7 @@ def spkcpo(
     outref: str,
     refloc: str,
     abcorr: str,
-    obspos: Iterable[float],
+    obspos: Union[ndarray, Iterable[float]],
     obsctr: str,
     obsref: str,
 ) -> Tuple[ndarray, float]:
@@ -11671,7 +11711,7 @@ def spkcpo(
 
 @spice_error_check
 def spkcpt(
-    trgpos: Iterable[float],
+    trgpos: Union[ndarray, Iterable[float]],
     trgctr: str,
     trgref: str,
     et: float,
@@ -11732,7 +11772,7 @@ def spkcvo(
     outref: str,
     refloc: str,
     abcorr: str,
-    obssta: Iterable[float],
+    obssta: Union[ndarray, Iterable[float]],
     obsepc: float,
     obsctr: str,
     obsref: str,
@@ -11787,7 +11827,7 @@ def spkcvo(
 
 @spice_error_check
 def spkcvt(
-    trgsta: Iterable[float],
+    trgsta: Union[ndarray, Iterable[float]],
     trgepc: float,
     trgctr: str,
     trgref: str,
@@ -12364,7 +12404,7 @@ def spkw02(
     intlen: float,
     n: int,
     polydg: int,
-    cdata: Iterable[float],
+    cdata: Union[ndarray, Iterable[float]],
     btime: float,
 ) -> None:
     """
@@ -12425,7 +12465,7 @@ def spkw03(
     intlen: float,
     n: int,
     polydg: int,
-    cdata: Iterable[float],
+    cdata: Union[ndarray, Iterable[float]],
     btime: float,
 ) -> None:
     """
@@ -12486,7 +12526,7 @@ def spkw05(
     gm: float,
     n: int,
     states: Union[ndarray, Iterable[Iterable[float]]],
-    epochs: Iterable[float],
+    epochs: Union[ndarray, Iterable[float]],
 ) -> None:
     # see libspice args for solution to array[][N] problem
     """
@@ -12598,7 +12638,7 @@ def spkw09(
     degree: int,
     n: int,
     states: Union[ndarray, Iterable[Iterable[float]]],
-    epochs: Iterable[float],
+    epochs: Union[ndarray, Iterable[float]],
 ) -> None:
     """
     Write a type 9 segment to an SPK file.
@@ -12642,10 +12682,10 @@ def spkw10(
     first: float,
     last: float,
     segid: str,
-    consts: Iterable[float],
+    consts: Union[ndarray, Iterable[float]],
     n: int,
-    elems: Iterable[float],
-    epochs: Iterable[float],
+    elems: Union[ndarray, Iterable[float]],
+    epochs: Union[ndarray, Iterable[float]],
 ) -> None:
     """
     Write an SPK type 10 segment to the DAF open and attached to
@@ -12754,7 +12794,7 @@ def spkw13(
     degree: int,
     n: int,
     states: Union[ndarray, Iterable[Iterable[float]]],
-    epochs: Iterable[float],
+    epochs: Union[ndarray, Iterable[float]],
 ) -> None:
     """
     Write a type 13 segment to an SPK file.
@@ -12804,7 +12844,7 @@ def spkw15(
     p: float,
     ecc: float,
     j2flg: float,
-    pv: Iterable[float],
+    pv: Union[ndarray, Iterable[float]],
     gm: float,
     j2: float,
     radius: float,
@@ -13677,7 +13717,9 @@ def sumai(array: Sequence[int]) -> int:
 
 
 @spice_error_check
-def surfnm(a: float, b: float, c: float, point: Iterable[float]) -> ndarray:
+def surfnm(
+    a: float, b: float, c: float, point: Union[ndarray, Iterable[float]]
+) -> ndarray:
     """
     This routine computes the outward-pointing, unit normal vector
     from a point on the surface of an ellipsoid.
@@ -13735,7 +13777,11 @@ def surfpt(
 @spice_error_check
 @spice_found_exception_thrower
 def surfpv(
-    stvrtx: Iterable[float], stdir: Iterable[float], a: float, b: float, c: float
+    stvrtx: Union[ndarray, Iterable[float]],
+    stdir: Union[ndarray, Iterable[float]],
+    a: float,
+    b: float,
+    c: float,
 ) -> Tuple[ndarray, bool]:
     """
     Find the state (position and velocity) of the surface intercept
@@ -13843,7 +13889,7 @@ def termpt(
     abcorr: str,
     corloc: str,
     obsrvr: str,
-    refvec: Iterable[float],
+    refvec: Union[ndarray, Iterable[float]],
     rolstp: float,
     ncuts: int,
     schstp: float,
@@ -14205,7 +14251,10 @@ def twopi() -> float:
 
 @spice_error_check
 def twovec(
-    axdef: Iterable[float], indexa: int, plndef: Iterable[float], indexp: int
+    axdef: Union[ndarray, Iterable[float]],
+    indexa: int,
+    plndef: Union[ndarray, Iterable[float]],
+    indexp: int,
 ) -> ndarray:
     """
     Find the transformation to the right-handed frame having a
@@ -14509,7 +14558,9 @@ def utc2et(utcstr: str) -> float:
 
 
 @spice_error_check
-def vadd(v1: Iterable[float], v2: Iterable[float]) -> ndarray:
+def vadd(
+    v1: Union[ndarray, Iterable[float]], v2: Union[ndarray, Iterable[float]]
+) -> ndarray:
     """Add two 3 dimensional vectors.
     https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/vadd_c.html
 
@@ -14525,7 +14576,9 @@ def vadd(v1: Iterable[float], v2: Iterable[float]) -> ndarray:
 
 
 @spice_error_check
-def vaddg(v1: Iterable[float], v2: Iterable[float], ndim: int) -> ndarray:
+def vaddg(
+    v1: Union[ndarray, Iterable[float]], v2: Union[ndarray, Iterable[float]], ndim: int
+) -> ndarray:
     """
     Add two n-dimensional vectors
     https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/vaddg_c.html
@@ -14748,11 +14801,11 @@ def vlcom(
 @spice_error_check
 def vlcom3(
     a: float,
-    v1: Iterable[float],
+    v1: Union[ndarray, Iterable[float]],
     b: float,
-    v2: Iterable[float],
+    v2: Union[ndarray, Iterable[float]],
     c: float,
-    v3: Iterable[float],
+    v3: Union[ndarray, Iterable[float]],
 ) -> ndarray:
     """
     This subroutine computes the vector linear combination
@@ -14914,7 +14967,7 @@ def vperp(a: ndarray, b: ndarray) -> ndarray:
 
 
 @spice_error_check
-def vprjp(vin: Iterable[float], plane: Plane) -> ndarray:
+def vprjp(vin: Union[ndarray, Iterable[float]], plane: Plane) -> ndarray:
     """
     Project a vector onto a specified plane, orthogonally.
 
@@ -14932,7 +14985,9 @@ def vprjp(vin: Iterable[float], plane: Plane) -> ndarray:
 
 @spice_error_check
 @spice_found_exception_thrower
-def vprjpi(vin: Iterable[float], projpl: Plane, invpl: Plane) -> Tuple[ndarray, bool]:
+def vprjpi(
+    vin: Union[ndarray, Iterable[float]], projpl: Plane, invpl: Plane
+) -> Tuple[ndarray, bool]:
     """
     Find the vector in a specified plane that maps to a specified
     vector in another plane under orthogonal projection.
@@ -14972,7 +15027,9 @@ def vproj(a: ndarray, b: ndarray) -> ndarray:
 
 
 @spice_error_check
-def vrel(v1: Iterable[float], v2: Iterable[float]) -> float:
+def vrel(
+    v1: Union[ndarray, Iterable[float]], v2: Union[ndarray, Iterable[float]]
+) -> float:
     """
     Return the relative difference between two 3-dimensional vectors.
 
@@ -14988,7 +15045,9 @@ def vrel(v1: Iterable[float], v2: Iterable[float]) -> float:
 
 
 @spice_error_check
-def vrelg(v1: Iterable[float], v2: Iterable[float], ndim: int) -> float:
+def vrelg(
+    v1: Union[ndarray, Iterable[float]], v2: Union[ndarray, Iterable[float]], ndim: int
+) -> float:
     """
     Return the relative difference between two vectors of general dimension.
 
@@ -15729,13 +15788,11 @@ def xposeg(matrix: Union[ndarray, Iterable[Iterable[float]]]) -> ndarray:
     https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/cspice/xposeg_c.html
 
     :param matrix: Matrix to be transposed
-    :param nrow: Number of rows of input matrix.
-    :param ncol: Number of columns of input matrix
     :return: Transposed matrix
     """
     ncol, nrow = len(matrix[0]), len(matrix)
     matrix = stypes.to_double_matrix(matrix)
-    mout = stypes.empty_double_matrix(x=ncol, y=nrow)
+    mout = stypes.empty_double_matrix(x=nrow, y=ncol)
     ncol = ctypes.c_int(ncol)
     nrow = ctypes.c_int(nrow)
     libspice.xposeg_c(matrix, nrow, ncol, mout)

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -28,7 +28,6 @@ import functools
 import ctypes
 from typing import Callable, Iterator, Iterable, Optional, Tuple, Union, Sequence
 
-OptionalInt = Optional[int]
 
 import numpy
 from numpy import ndarray, str_
@@ -71,6 +70,7 @@ from .utils.support_types import (
 __author__ = "AndrewAnnex"
 
 ################################################################################
+OptionalInt = Optional[int]
 
 _default_len_out = 256
 
@@ -8871,7 +8871,7 @@ def mtxv(m1: ndarray, vin: ndarray) -> ndarray:
 
 
 @spice_error_check
-def mtxvg(m1: ndarray, v2: ndarray, ncol1: int, nr1r2: int) -> ndarray:
+def mtxvg(m1: ndarray, v2: ndarray, ncol1: OptionalInt = None, nr1r2: OptionalInt = None) -> ndarray:
     """
     Multiply the transpose of a matrix and
     a vector of arbitrary size.
@@ -8921,9 +8921,9 @@ def mxm(
 def mxmg(
     m1: Iterable[Iterable[float]],
     m2: Iterable[Iterable[float]],
-    nrow1: int,
-    ncol1: int,
-    ncol2: int,
+    nrow1: OptionalInt = None,
+    ncol1: OptionalInt = None,
+    ncol2: OptionalInt = None,
 ) -> ndarray:
     """
     Multiply two double precision matrices of arbitrary size.
@@ -15256,7 +15256,7 @@ def vtmv(v1: ndarray, matrix: ndarray, v2: ndarray) -> float:
 
 
 @spice_error_check
-def vtmvg(v1: ndarray, matrix: ndarray, v2: ndarray, nrow: int, ncol: int) -> float:
+def vtmvg(v1: ndarray, matrix: ndarray, v2: ndarray, nrow: OptionalInt = None, ncol: OptionalInt = None) -> float:
     """
     Multiply the transpose of a n-dimensional
     column vector a nxm matrix,
@@ -15817,7 +15817,7 @@ def xpose6(m: Union[ndarray, Iterable[Iterable[float]]]) -> ndarray:
 
 @spice_error_check
 def xposeg(
-    matrix: Union[ndarray, Iterable[Iterable[float]]], nrow: int, ncol: int
+    matrix: Union[ndarray, Iterable[Iterable[float]]], nrow: OptionalInt = None, ncol: OptionalInt = None
 ) -> ndarray:
     """
     Transpose a matrix of arbitrary size

--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -2408,7 +2408,9 @@ def dgeodr(x: float, y: float, z: float, re: float, f: float) -> ndarray:
 
 
 @spice_error_check
-def diags2(symmat: Union[ndarray, Iterable[Iterable[float]]]) -> Tuple[ndarray, ndarray]:
+def diags2(
+    symmat: Union[ndarray, Iterable[Iterable[float]]]
+) -> Tuple[ndarray, ndarray]:
     """
     Diagonalize a symmetric 2x2 matrix.
 
@@ -8858,7 +8860,10 @@ def mtxvg(m1: ndarray, v2: ndarray) -> ndarray:
 
 
 @spice_error_check
-def mxm(m1: Union[ndarray, Iterable[Iterable[float]]], m2: Union[ndarray, Iterable[Iterable[float]]]) -> ndarray:
+def mxm(
+    m1: Union[ndarray, Iterable[Iterable[float]]],
+    m2: Union[ndarray, Iterable[Iterable[float]]],
+) -> ndarray:
     """
     Multiply two 3x3 matrices.
 
@@ -8901,7 +8906,10 @@ def mxmg(
 
 
 @spice_error_check
-def mxmt(m1: Union[ndarray, Iterable[Iterable[float]]], m2: Union[ndarray, Iterable[Iterable[float]]]) -> ndarray:
+def mxmt(
+    m1: Union[ndarray, Iterable[Iterable[float]]],
+    m2: Union[ndarray, Iterable[Iterable[float]]],
+) -> ndarray:
     """
     Multiply a 3x3 matrix and the transpose of another 3x3 matrix.
 
@@ -10159,7 +10167,9 @@ def radrec(inrange: float, re: float, dec: float) -> ndarray:
 
 
 @spice_error_check
-def rav2xf(rot: Union[ndarray, Iterable[Iterable[float]]], av: Iterable[float]) -> ndarray:
+def rav2xf(
+    rot: Union[ndarray, Iterable[Iterable[float]]], av: Iterable[float]
+) -> ndarray:
     """
     This routine determines a state transformation matrix
     from a rotation matrix and the angular velocity of the

--- a/spiceypy/tests/test_wrapper.py
+++ b/spiceypy/tests/test_wrapper.py
@@ -3942,7 +3942,7 @@ def test_gfevnt():
     udrepu = spiceypy.utils.callbacks.SpiceUDREPU(spice.gfrepu)
     udrepf = spiceypy.utils.callbacks.SpiceUDREPF(spice.gfrepf)
     udbail = spiceypy.utils.callbacks.SpiceUDBAIL(spice.gfbail)
-    qdpars = np.zeros(10, dtype=np.float)
+    qdpars = np.zeros(10, dtype=float)
     qipars = np.zeros(10, dtype=np.int32)
     qlpars = np.zeros(10, dtype=np.int32)
     # call gfevnt

--- a/spiceypy/tests/test_wrapper.py
+++ b/spiceypy/tests/test_wrapper.py
@@ -10537,7 +10537,7 @@ def test_xposeg():
         spice.xposeg(np.array(m1)),
         [[1.0, 0.0, 0.0], [2.0, 4.0, 6.0], [3.0, 5.0, 0.0]],
     )
-    m2 = np.random.rand((3, 4))
+    m2 = np.random.rand(3, 4)
     npt.assert_array_almost_equal(spice.xposeg(m2), m2.T)
 
 

--- a/spiceypy/tests/test_wrapper.py
+++ b/spiceypy/tests/test_wrapper.py
@@ -5862,7 +5862,7 @@ def test_mtxm():
 def test_mtxmg():
     m1 = np.array([[1.0, 2.0, 3.0, 0.0], [1.0, 1.0, 1.0, 1.0]])
     m2 = np.array([[1.0, 2.0, 3.0], [0.0, 0.0, 0.0]])
-    mout = spice.mtxmg(m1, m2, 4, 2, 3)
+    mout = spice.mtxmg(m1, m2)
     expected = np.array(
         [[1.0, 2.0, 3.0], [2.0, 4.0, 6.0], [3.0, 6.0, 9.0], [0.0, 0.0, 0.0]]
     )
@@ -5880,7 +5880,7 @@ def test_mtxv():
 def test_mtxvg():
     m1 = np.array([[1.0, 2.0], [1.0, 3.0], [1.0, 4.0]])
     v2 = np.array([1.0, 2.0, 3.0])
-    mout = spice.mtxvg(m1, v2, 2, 3)
+    mout = spice.mtxvg(m1, v2)
     expected = np.array([6.0, 20.0])
     assert np.array_equal(mout, expected)
 
@@ -5898,10 +5898,7 @@ def test_mxm():
 def test_mxmg():
     m1 = [[1.0, 4.0], [2.0, 5.0], [3.0, 6.0]]
     m2 = [[1.0, 2.0, 3.0], [2.0, 4.0, 6.0]]
-    nrow1 = 3
-    ncol1 = 2
-    ncol2 = 3
-    mout = np.array(spice.mxmg(m1, m2, nrow1, ncol1, ncol2))
+    mout = np.array(spice.mxmg(m1, m2))
     m1 = np.array(m1)
     m2 = np.array(m2)
     mout2 = np.dot(m1, m2)
@@ -10189,7 +10186,7 @@ def test_vtmvg():
     v1 = np.array([1.0, 2.0, 3.0])
     v2 = np.array([1.0, 2.0])
     matrix = np.array([[2.0, 0.0], [1.0, 2.0], [1.0, 1.0]])
-    assert spice.vtmvg(v1, matrix, v2, 3, 2) == 21.0
+    assert spice.vtmvg(v1, matrix, v2) == 21.0
 
 
 def test_vupack():
@@ -10534,12 +10531,14 @@ def test_xpose():
 def test_xposeg():
     m1 = [[1.0, 2.0, 3.0], [0.0, 4.0, 5.0], [0.0, 6.0, 0.0]]
     npt.assert_array_almost_equal(
-        spice.xposeg(m1, 3, 3), [[1.0, 0.0, 0.0], [2.0, 4.0, 6.0], [3.0, 5.0, 0.0]]
+        spice.xposeg(m1), [[1.0, 0.0, 0.0], [2.0, 4.0, 6.0], [3.0, 5.0, 0.0]]
     )
     npt.assert_array_almost_equal(
-        spice.xposeg(np.array(m1), 3, 3),
+        spice.xposeg(np.array(m1)),
         [[1.0, 0.0, 0.0], [2.0, 4.0, 6.0], [3.0, 5.0, 0.0]],
     )
+    m2 = np.random.rand((3, 4))
+    npt.assert_array_almost_equal(spice.xposeg(m2), m2.T)
 
 
 def test_zzdynrot():

--- a/spiceypy/tests/test_wrapper.py
+++ b/spiceypy/tests/test_wrapper.py
@@ -5930,6 +5930,14 @@ def test_mxv():
 def test_mxvg():
     m1 = np.array([[1.0, 1.0, 1.0], [2.0, 3.0, 4.0]])
     v2 = np.array([1.0, 2.0, 3.0])
+    mout = spice.mxvg(m1, v2)
+    expected = np.array([6.0, 20.0])
+    assert np.array_equal(mout, expected)
+    
+
+def test_mxvg_old_api():
+    m1 = np.array([[1.0, 1.0, 1.0], [2.0, 3.0, 4.0]])
+    v2 = np.array([1.0, 2.0, 3.0])
     mout = spice.mxvg(m1, v2, 2, 3)
     expected = np.array([6.0, 20.0])
     assert np.array_equal(mout, expected)


### PR DESCRIPTION
Simplifying functions with ncol/nrow params
    
Some of the early functions I implemented for SpiceyPy were the linear
algebra functions which aren't critical. In those I left some of the
argument row/col dimension arguments which SpiceyPy can figure out for
the user. First pass at fixing some of those and other type annotation
issues I saw.