### PR TITLE
Updated getfat variables size

### DIFF
--- a/spiceypy/spiceypy.py
+++ b/spiceypy/spiceypy.py
@@ -5557,8 +5557,8 @@ def getfat(file: str) -> Tuple[str, str]:
     :return: The architecture of the kernel file, The type of the kernel file.
     """
     file = stypes.string_to_char_p(file)
-    arclen = ctypes.c_int(4)
-    typlen = ctypes.c_int(4)
+    arclen = ctypes.c_int(5)
+    typlen = ctypes.c_int(5)
     arch = stypes.string_to_char_p(arclen)
     rettype = stypes.string_to_char_p(typlen)
     libspice.getfat_c(file, arclen, typlen, arch, rettype)

--- a/spiceypy/tests/test_wrapper.py
+++ b/spiceypy/tests/test_wrapper.py
@@ -3576,6 +3576,10 @@ def test_getfat():
     arch, outtype = spice.getfat(CoreKernels.lsk)
     assert arch == "KPL"
     assert outtype == "LSK"
+    # Add test for resulting string with length > 3.
+    arch, outtype = spice.getfat(CassiniKernels.cassSclk)
+    assert arch == "KPL"
+    assert outtype == "SCLK"
 
 
 def test_getfov():


### PR DESCRIPTION
I found a bug in the getfat_c wrapper, concerning the default length for the typelen argument; it is set to 4, that leads to a three letter truncation and ‘SCLK’ is truncated to ‘SCL’.

The correction updates the lenght of the arclen and typlen variables to 5 to accomodate a 4 character string.

Tests have been updated accordingly.