### PR TITLE
fixes failing ci builds

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -134,7 +134,7 @@ jobs:
           python -m pip install -U -r ci-requirements.txt
       - name: Download and extract CSPICE 🌶️ 
         run: |
-          wget -O - https://naif.jpl.nasa.gov/pub/naif/toolkit/C/PC_Linux_GCC_64bit/packages/cspice.tar.Z | gunzip -c | tar xC /tmp/ 
+          wget -O - https://naif.jpl.nasa.gov/pub/naif/misc/toolkit_N0066/C/PC_Linux_GCC_64bit/packages/cspice.tar.Z | gunzip -c | tar xC /tmp/ 
       - name: Install SpiceyPy 🌶️ 🥧
         env:
           CSPICE_SRC_DIR: "/tmp/cspice"

--- a/ci-requirements.txt
+++ b/ci-requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.17.0
 setuptools>=38.0.0
-pytest>=5.4.0
+pytest>=7.0.0
 pandas>=0.24.0
 coverage>=5.1.0
 codecov>=2.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,14 +44,14 @@ include_package_data = True
 zip_safe = False
 install_requires =
     numpy>=1.17.0
-tests_require = numpy>=1.17.0; pytest>=2.9.0; pandas>=0.24.0
+tests_require = numpy>=1.17.0; pytest>=7.0.0; pandas>=0.24.0
 
 [options.packages.find]
 where = src
 
 [options.extras_require]
-tests = numpy>=1.17.0; pytest>=2.9.0; pandas>=0.24.0
-dev = numpy>=1.17.0; pytest>=2.9.0; pandas>=0.24.0; coverage>=5.1.0; codecov>=2.1.0; twine>=3.3.0; wheel; build; black;
+tests = numpy>=1.17.0; pytest>=7.0.0; pandas>=0.24.0
+dev = numpy>=1.17.0; pytest>=7.0.0; pandas>=0.24.0; coverage>=5.1.0; codecov>=2.1.0; twine>=3.3.0; wheel; build; black;
 
 [options.package_data]
 * = get_spice.py, LICENSE, README.rst, *.so, *.dll, *.dylib

--- a/src/spiceypy/tests/test_wrapper.py
+++ b/src/spiceypy/tests/test_wrapper.py
@@ -4984,7 +4984,7 @@ def test_kepleq():
     k = eqel_2 * can - eqel_1 * san
     ml = eqel_3 + ((n * dt) % spice.twopi())
     eecan = spice.kepleq(ml, h, k)
-    assert pytest.approx(2.692595464274983, eecan)
+    assert 2.692595464274983 == pytest.approx(eecan)
 
 
 def test_kinfo():
@@ -5008,7 +5008,7 @@ def test_kpsolv():
             k = r * np.sin(theta)
             x = spice.kpsolv((h, k))
             fx = h * np.cos(x) + k * np.sin(x)
-            assert pytest.approx(fx, x, 1.0e-15)
+            assert fx == pytest.approx(x, 1.0e-15)
             theta = theta + 0.1
         r = r + 0.05
         pass

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.17.0
 setuptools>=38.0.0
-pytest>=5.4.0
+pytest>=7.0.0
 pandas>=0.24.0


### PR DESCRIPTION
* pytest had a new release which raised errors for bad usage of a assert
function, causing 2 tests to fail, bumped pytest to  >=7.0.0

* cspice version bumb caused offline builds to fail do to redundant
  patches, great news for n67 bump