### PR TITLE
Add py.typed marker so type checkers see spiceypy's annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
      "Programming Language :: Python :: 3.13",
      "Programming Language :: Python :: 3.14",
      "Programming Language :: Cython",
+     "Typing :: Typed",
      "Operating System :: MacOS :: MacOS X",
      "Operating System :: POSIX :: Linux",
      "Operating System :: POSIX :: BSD :: FreeBSD",
@@ -106,6 +107,7 @@ cmake.build-type = "Release"
 
 # TODO probably will want to consider excluding tests due to changing standards
 sdist.include = [
+    "src/spiceypy/py.typed",
     "src/spiceypy/*.py",
     "src/spiceypy/benchmarks/*.py",
     "src/spiceypy/test/*.py",


### PR DESCRIPTION
Fixes #415.

This adds the PEP 561 py.typed marker plus the two packaging lines needed to ship it: the Typing :: Typed classifier and an sdist.include entry, since the existing include globs only match *.py and *.pyx. The wheel side needs no change because scikit-build-core's package auto-detection picks up non-Python files inside src/spiceypy; I confirmed that with a minimal repro pinned to the same scikit-build-core version, and verified the built sdist contains src/spiceypy/py.typed.

On the concern from the 2021 discussion about internal mypy errors: shipping the marker does not expose them to users. mypy does not re-check site-packages internals when following imports, so downstream projects only see the public annotations. I demonstrated the user-facing effect in a fresh venv against the 8.1.2 wheel: before the marker, mypy reports import-untyped and silently ignores two deliberate type errors in user code calling spiceypy; with the marker present, both are caught ([assignment] and [arg-type]). A mypy pass over spiceypy's own internals would be worthwhile as an independent follow-up, but it is not a prerequisite for the marker.