### PR TITLE
Fix a few quirks of test temporary directory management

### DIFF
--- a/src/spiceypy/tests/gettestkernels.py
+++ b/src/spiceypy/tests/gettestkernels.py
@@ -56,7 +56,7 @@ except Exception:
     _HAVE_REQUESTS = False
 
 
-cwd = "/tmp" if platform.system() == "Darwin" else tempfile.gettempdir()
+cwd = tempfile.gettempdir()
 
 
 def get_kernel_name_from_url(url: str) -> str:

--- a/src/spiceypy/tests/gettestkernels.py
+++ b/src/spiceypy/tests/gettestkernels.py
@@ -68,8 +68,10 @@ def get_path_from_url(url: str) -> str:
 
 
 def cleanup_file(path: str) -> None:
-    if os.path.exists(path):
+    try:
         os.remove(path)
+    except FileNotFoundError:
+        pass
 
 
 class CassiniKernels(object):

--- a/src/spiceypy/tests/gettestkernels.py
+++ b/src/spiceypy/tests/gettestkernels.py
@@ -194,6 +194,7 @@ def cleanup_core_kernels() -> None:
     cleanup_file(CoreKernels.spk)
     cleanup_file(CoreKernels.gm_pck)
     cleanup_file(CoreKernels.lsk)
+    cleanup_file(CoreKernels.testMetaKernel)
 
 
 def get_kernel(url: str, provided_hash: str = None):
@@ -319,7 +320,7 @@ def get_cassini_test_kernels() -> None:
 
 def write_test_meta_kernel() -> None:
     # Update the paths!
-    with open(os.path.join(cwd, "exampleKernels.txt"), "w") as kernelFile:
+    with open(CoreKernels.testMetaKernel, "w") as kernelFile:
         kernelFile.write("\\begindata\n")
         kernelFile.write("KERNELS_TO_LOAD = (\n")
         for kernel in CoreKernels.standardKernelList:


### PR DESCRIPTION
 - Don’t special-case macOS’s temporary directory in tests
 - Remove exampleKernels.txt during test clean-up
 - Skip redundant filesystem checks during test clean-up