### PR TITLE
Fix ctypes argtypes typos and erroneous double-byref calls

### DIFF
--- a/src/spiceypy/spiceypy.py
+++ b/src/spiceypy/spiceypy.py
@@ -2378,7 +2378,7 @@ def dafrs(insum: ndarray) -> None:
     :param insum: New summary for current array.
     """
     insum = stypes.to_double_vector(insum)
-    libspice.dafrs_c(ctypes.byref(insum))
+    libspice.dafrs_c(insum)
 
 
 @spice_error_check
@@ -10799,7 +10799,7 @@ def polyds(
     p = stypes.empty_double_vector(nderiv + 1)
     nderiv = ctypes.c_int(nderiv)
     t = ctypes.c_double(t)
-    libspice.polyds_c(ctypes.byref(coeffs), deg, nderiv, t, p)
+    libspice.polyds_c(coeffs, deg, nderiv, t, p)
     return stypes.c_vector_to_python(p)
 
 

--- a/src/spiceypy/utils/libspicehelper.py
+++ b/src/spiceypy/utils/libspicehelper.py
@@ -454,7 +454,7 @@ libspice.dafrfr_c.argtypes = [
     c_int_p,
     c_int_p,
 ]
-libspice.dafrs_c.argtype = [c_double_p]
+libspice.dafrs_c.argtypes = [c_double_p]
 libspice.dafus_c.argtypes = [c_double_p, c_int, c_int, c_double_p, c_int_p]
 libspice.dasac_c.argtypes = [c_int, c_int, c_int, c_void_p]
 libspice.dasadc_c.argtypes = [c_int, c_int, c_int, c_int, c_int, c_void_p]
@@ -1109,7 +1109,7 @@ libspice.gffove_c.argtypes = [
     s_cell_p,
 ]
 libspice.gfinth_c.argtypes = [c_int]
-libspice.gfilum_c.argtupes = [
+libspice.gfilum_c.argtypes = [
     c_char_p,
     c_char_p,
     c_char_p,
@@ -1722,7 +1722,7 @@ libspice.pltnrm_c.argtypes = [
 ]
 libspice.pltvol_c.argtypes = [c_int, c_void_p, c_int, c_void_p]
 libspice.pltvol_c.restype = c_double
-libspice.polyds_c.argtype = [c_double_p, c_int, c_int, c_double, c_double_p]
+libspice.polyds_c.argtypes = [c_double_p, c_int, c_int, c_double, c_double_p]
 libspice.pos_c.argtypes = [c_char_p, c_char_p, c_int]
 libspice.pos_c.restype = c_int
 libspice.posr_c.argtypes = [c_char_p, c_char_p, c_int]
@@ -2533,9 +2533,9 @@ libspice.vlcomg_c.argtypes = [
 libspice.vminug_c.argtypes = [c_double_p, c_int, c_double_p]
 libspice.vminus_c.argtypes = [(c_double * 3), (c_double * 3)]
 libspice.vnorm_c.restype = c_double
-libspice.vnorm_c.argstype = [stypes.empty_double_vector(3)]
+libspice.vnorm_c.argtypes = [c_double * 3]
 libspice.vnormg_c.restype = c_double
-libspice.vnormg_c.argstype = [c_double_p, c_int]
+libspice.vnormg_c.argtypes = [c_double_p, c_int]
 libspice.vpack_c.argtypes = [c_double, c_double, c_double, (c_double * 3)]
 libspice.vperp_c.argtypes = [(c_double * 3), (c_double * 3), (c_double * 3)]
 libspice.vprjp_c.argtypes = [(c_double * 3), s_plan_p, (c_double * 3)]


### PR DESCRIPTION
libspicehelper.py had four misspelled attribute names (.argtype/.argtupes/.argstype instead of .argtypes) on dafrs_c, gfilum_c, polyds_c, and vnormg_c, plus vnorm_c's argtypes was set to a call result instead of a ctypes type. Because ctypes silently allows setting arbitrary attributes on a function pointer, these typos meant CSPICE argument marshalling was never actually enabled for those functions.

dafrs() and polyds() separately wrapped their already-ctypes-array arguments in an extra ctypes.byref(), producing a bad pointer-to-pointer once dafrs_c/polyds_c's argtypes correctly expect a bare pointer.